### PR TITLE
fix: stopped crashes when collaborator is not defined on the manifest

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -75,8 +75,8 @@ export default {
     ...mapGetters(['manifest']),
     collaborator() {
       if (this.$route.params.key) {
-        const { collaborator } = this.manifest(this.$route) || {}
-        return collaborator
+        const { collaborator } = this.manifest(this.$route)
+        return collaborator || {}
       }
       return {}
     }


### PR DESCRIPTION
Fix to #168 