### PR TITLE
fix: graphs not updated when switching file (#173)

### DIFF
--- a/components/graphs/TrackerGraph.vue
+++ b/components/graphs/TrackerGraph.vue
@@ -105,6 +105,11 @@ export default {
       results: []
     }
   },
+  watch: {
+    values(oldValues) {
+      this.drawViz()
+    }
+  },
   mounted() {
     this.drawViz()
   },

--- a/components/graphs/TwitterOverview.vue
+++ b/components/graphs/TwitterOverview.vue
@@ -123,6 +123,11 @@ export default {
       results: []
     }
   },
+  watch: {
+    values(oldValues) {
+      this.drawViz()
+    }
+  },
   mounted() {
     this.drawViz()
   },

--- a/components/graphs/UberOverview.vue
+++ b/components/graphs/UberOverview.vue
@@ -218,6 +218,11 @@ export default {
       results: []
     }
   },
+  watch: {
+    values(oldValues) {
+      this.drawViz()
+    }
+  },
   mounted() {
     this.drawViz()
   },


### PR DESCRIPTION
The graphs component did not call the `drawViz` function when the values change. It's fixed by using a `watch` property. Keep in mind for future graph components.

Close #173