### PR TITLE
feat: allow configuring whether to show data explorer for each experience

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -92,6 +92,10 @@ export default {
     isGenericViewer: {
       type: Boolean,
       default: false
+    },
+    showDataExplorer: {
+      type: Boolean,
+      default: true
     }
   },
   computed: {
@@ -112,7 +116,8 @@ export default {
         'defaultView',
         'customPipeline',
         'preprocessor',
-        'isGenericViewer'
+        'isGenericViewer',
+        'showDataExplorer'
       ]
       const props = Object.fromEntries(propNames.map(k => [k, this[k]]))
       return props

--- a/components/TheDataExperienceDefault.vue
+++ b/components/TheDataExperienceDefault.vue
@@ -53,7 +53,7 @@
           />
         </v-col>
       </v-row>
-      <v-row>
+      <v-row v-if="showDataExplorer">
         <v-col>
           <unit-file-explorer v-bind="{ allFiles, preprocessor }" />
         </v-col>
@@ -87,7 +87,8 @@ export default {
     dataPortal: String,
     customPipeline: Function,
     preprocessor: String,
-    isGenericViewer: Boolean
+    isGenericViewer: Boolean,
+    showDataExplorer: Boolean
   },
   data() {
     // main example is selected by default

--- a/manifests/experiences/explorer/explorer.json
+++ b/manifests/experiences/explorer/explorer.json
@@ -2,5 +2,6 @@
   "title": "Data Explorer",
   "icon": "clipboard-search-outline.png",
   "isGenericViewer": true,
+  "showDataExplorer": true,
   "ext": "all"
 }

--- a/manifests/index.js
+++ b/manifests/index.js
@@ -71,6 +71,7 @@ const manifests = Object.fromEntries(
       preprocessor,
       collaborator,
       isGenericViewer,
+      showDataExplorer,
       ...rest
     } = reqJSON(path)
 
@@ -111,6 +112,10 @@ const manifests = Object.fromEntries(
       throw new Error(`[${dir}] Preprocessor ${preprocessor} does not exist`)
     }
 
+    if (isGenericViewer && !showDataExplorer) {
+      throw new Error('the explorer experience must show the data explorer')
+    }
+
     const module = require(`./experiences/${dir}/`)
 
     return [
@@ -126,6 +131,7 @@ const manifests = Object.fromEntries(
         preprocessor,
         collaborator,
         isGenericViewer,
+        showDataExplorer,
         ...rest,
         ...module.default,
         examples: []


### PR DESCRIPTION
Addressing #188.

Added a key `showDataExplorer` to the manifest of each experience, controlling whether the data explorer component is shown at the bottom of the page or not.
The default value is true.