### PR TITLE
feat: each experience can have a different custom pipeline

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -85,9 +85,9 @@ export default {
       type: Boolean,
       default: false
     },
-    customPipeline: {
-      type: Function,
-      default: undefined
+    customPipelines: {
+      type: Object,
+      default: () => {}
     },
     isGenericViewer: {
       type: Boolean,
@@ -110,7 +110,7 @@ export default {
         'examples',
         'visualizations',
         'defaultView',
-        'customPipeline',
+        'customPipelines',
         'preprocessor',
         'isGenericViewer'
       ]

--- a/components/TheDataExperienceDefault.vue
+++ b/components/TheDataExperienceDefault.vue
@@ -34,7 +34,8 @@
               visualizations,
               defaultViewElements,
               selectedExample,
-              customPipeline: customPipeline,
+              customPipeline:
+                customPipelines[defaultViewElements.customPipeline],
               inputFiles,
               i: index
             }"
@@ -85,7 +86,7 @@ export default {
     defaultView: Array,
     title: String,
     dataPortal: String,
-    customPipeline: Function,
+    customPipelines: Object,
     preprocessor: String,
     isGenericViewer: Boolean
   },

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -84,7 +84,7 @@ Note: All files and folders should match the following regular expression: [`^(?
   /**
     * Array defining the blocks to show in the default view. Each section section can have:
     * - A SPARQL query (optional)
-    * - A function used as the custom pipeline
+    * - A function used as the custom pipeline (defined in pipeline.js) (optional)
     * - An array of visualizations to show
     * - A data table
     * - A title

--- a/manifests/experiences/tracker-control/index.js
+++ b/manifests/experiences/tracker-control/index.js
@@ -1,5 +1,5 @@
-import customPipeline from './pipeline'
+import customPipelines from './pipeline'
 
 export default {
-  customPipeline
+  customPipelines
 }

--- a/manifests/experiences/tracker-control/pipeline.js
+++ b/manifests/experiences/tracker-control/pipeline.js
@@ -1,6 +1,6 @@
 import * as csv from '@fast-csv/parse'
 
-export default async function (inputFiles) {
+async function trackerControl(inputFiles) {
   const data = Object.values(inputFiles)[0]
   return await new Promise(resolve => {
     const items = []
@@ -9,4 +9,8 @@ export default async function (inputFiles) {
       .on('data', row => items.push(row))
       .on('end', () => resolve({ headers: Object.keys(items[0]), items }))
   })
+}
+
+export default {
+  trackerControl
 }

--- a/manifests/experiences/tracker-control/tracker-control.json
+++ b/manifests/experiences/tracker-control/tracker-control.json
@@ -6,7 +6,7 @@
   "data": ["tracker-control.csv"],
   "defaultView": [
     {
-      "customPipeline": true,
+      "customPipeline": "trackerControl",
       "visualizations": ["TrackerGraph.vue"],
       "showTable": false,
       "title": "Tracker control experience",

--- a/manifests/experiences/twitter/index.js
+++ b/manifests/experiences/twitter/index.js
@@ -1,5 +1,5 @@
-import customPipeline from './pipeline'
+import customPipelines from './pipeline'
 
 export default {
-  customPipeline
+  customPipelines
 }

--- a/manifests/experiences/twitter/pipeline.js
+++ b/manifests/experiences/twitter/pipeline.js
@@ -21,7 +21,7 @@ function fillItems(items, impressionAttributes, isEngagement) {
   })
 }
 
-export default async function (inputFiles) {
+async function twitterTargeting(inputFiles) {
   const engagementsFile = JSON.parse(inputFiles['data/ad-engagements.js'])
   const impressionsFile = JSON.parse(inputFiles['data/ad-impressions.js'])
   const engagements = JSONPath({
@@ -45,4 +45,8 @@ export default async function (inputFiles) {
   fillItems(items, engagements, true)
 
   return await Promise.resolve({ headers, items })
+}
+
+export default {
+  twitterTargeting
 }

--- a/manifests/experiences/twitter/twitter.json
+++ b/manifests/experiences/twitter/twitter.json
@@ -67,7 +67,7 @@
       "text": "Visualize the targeting criteria used by one specific advertiser. You can look up the names in the table above and write it in the text field below."
     },
     {
-      "customPipeline": true,
+      "customPipeline": "twitterTargeting",
       "visualizations": ["TwitterOverview.vue"],
       "showTable": false,
       "title": "Twitter advertising overview",

--- a/manifests/experiences/uber/index.js
+++ b/manifests/experiences/uber/index.js
@@ -1,5 +1,5 @@
-import customPipeline from './pipeline'
+import customPipelines from './pipeline'
 
 export default {
-  customPipeline
+  customPipelines
 }

--- a/manifests/experiences/uber/pipeline.js
+++ b/manifests/experiences/uber/pipeline.js
@@ -1,6 +1,6 @@
 import * as csv from '@fast-csv/parse'
 
-export default async function (inputFiles) {
+async function tripsData(inputFiles) {
   const data = inputFiles['Rider/trips_data.csv']
   return await new Promise(resolve => {
     const items = []
@@ -9,4 +9,8 @@ export default async function (inputFiles) {
       .on('data', row => items.push(row))
       .on('end', () => resolve({ headers: Object.keys(items[0]), items }))
   })
+}
+
+export default {
+  tripsData
 }

--- a/manifests/experiences/uber/uber.json
+++ b/manifests/experiences/uber/uber.json
@@ -8,7 +8,7 @@
   "data": ["uber-trips.zip"],
   "defaultView": [
     {
-      "customPipeline": true,
+      "customPipeline": "tripsData",
       "visualizations": ["UberOverview.vue"],
       "showTable": false,
       "title": "Uber Trips overview",


### PR DESCRIPTION
This will be necessary because we are soon going to replace twitter experiences, using custom pipelines instead of sparql pipelines