### PR TITLE
Fixed file tree in UnitFileViewer

### DIFF
--- a/components/UnitCsvViewer.vue
+++ b/components/UnitCsvViewer.vue
@@ -46,11 +46,11 @@ export default {
       this.csvText = this.preprocessorFunc(await file.text())
       try {
         this.csvContent = await this.csvToItems(this.csvText)
+        this.error = false
       } catch (error) {
         this.error = true
       }
       this.loading = false
-      this.error = false
     },
     async csvToItems(csvText) {
       return await new Promise(resolve => {

--- a/components/UnitFileExplorer.vue
+++ b/components/UnitFileExplorer.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script>
-import FileTree from '~/utils/file.js'
+import FileManager from '~/utils/file.js'
 import UnitJsonViewer from '~/components/UnitJsonViewer'
 import UnitCsvViewer from '~/components/UnitCsvViewer'
 import UnitPdfViewer from '~/components/UnitPdfViewer'
@@ -104,7 +104,7 @@ export default {
       selectedItem: null,
       openItems: [],
       idSpace: 0,
-      fileTree: null,
+      fileManager: null,
       fileItems: []
     }
   },
@@ -118,8 +118,9 @@ export default {
     }
   },
   async created() {
-    this.fileTree = await new FileTree(this.allFiles)
-    this.fileItems = this.fileTree.makeItems(this.fileTree.tree)
+    this.fileManager = await new FileManager(this.allFiles)
+    const fileTree = this.fileManager.makeTree(this.fileManager.fileList)
+    this.fileItems = this.fileManager.makeItems(fileTree)
   },
   methods: {
     setSelectedItem(array) {

--- a/components/UnitFileExplorer.vue
+++ b/components/UnitFileExplorer.vue
@@ -15,12 +15,12 @@
                 rounded
                 return-object
                 transition
-                :items="fileTree"
+                :items="fileItems"
                 @update:active="setSelectedItem"
               >
                 <template #prepend="{ item }">
                   <v-icon>
-                    {{ filetype2icon[item.type] || filetype2icon.file }}
+                    {{ item.icon }}
                   </v-icon>
                 </template>
               </v-treeview>
@@ -70,20 +70,7 @@
 </template>
 
 <script>
-import {
-  mdiCodeJson,
-  mdiFile,
-  mdiFileImage,
-  mdiFilePdfBox,
-  mdiFolder,
-  mdiFolderZip,
-  mdiTable,
-  mdiTextBoxOutline,
-  mdiXml
-} from '@mdi/js'
-import { unzip, setOptions } from 'unzipit'
-import workerURL from 'unzipit/dist/unzipit-worker.module.js'
-import { cloneDeep } from 'lodash'
+import FileTree from '~/utils/file.js'
 import UnitJsonViewer from '~/components/UnitJsonViewer'
 import UnitCsvViewer from '~/components/UnitCsvViewer'
 import UnitPdfViewer from '~/components/UnitPdfViewer'
@@ -91,11 +78,6 @@ import preprocessors from '~/manifests/preprocessors'
 import UnitImageViewer from '~/components/UnitImageViewer'
 import UnitHtmlViewer from '~/components/UnitHtmlViewer'
 import UnitTextViewer from '~/components/UnitTextViewer'
-
-setOptions({
-  workerURL,
-  numWorkers: 2
-})
 
 export default {
   name: 'UnitFileExplorer',
@@ -121,36 +103,9 @@ export default {
     return {
       selectedItem: null,
       openItems: [],
-      filetype2icon: {
-        folder: mdiFolder,
-        zip: mdiFolderZip,
-        json: mdiCodeJson,
-        csv: mdiTable,
-        pdf: mdiFilePdfBox,
-        img: mdiFileImage,
-        file: mdiFile,
-        txt: mdiTextBoxOutline,
-        html: mdiXml
-      },
-      extension2filetype: {
-        tar: 'zip',
-        js: 'json',
-        png: 'img',
-        jpeg: 'img',
-        jpg: 'img',
-        gif: 'img',
-        bmp: 'img',
-        webp: 'img',
-        pdf: 'pdf',
-        zip: 'zip',
-        json: 'json',
-        txt: 'txt',
-        html: 'html',
-        csv: 'csv',
-        tsv: 'csv'
-      },
       idSpace: 0,
-      fileTree: []
+      fileTree: null,
+      fileItems: []
     }
   },
   computed: {
@@ -163,8 +118,8 @@ export default {
     }
   },
   async created() {
-    const result = await this.fileListToTree(this.allFiles)
-    this.fileTree = this.itemifyFiles(result)
+    this.fileTree = await new FileTree(this.allFiles)
+    this.fileItems = this.fileTree.makeItems(this.fileTree.tree)
   },
   methods: {
     setSelectedItem(array) {
@@ -172,98 +127,6 @@ export default {
       const containers = new Set(['folder', 'zip'])
       if (!containers.has(item?.type)) {
         this.selectedItem = item
-      }
-    },
-    async zipEntriesToTree(entryList) {
-      const folders = entryList.filter(node => node.isDirectory)
-      const folderContents = Object.fromEntries(
-        folders.map(folder => [
-          folder.name,
-          entryList.filter(f => new RegExp(`^${folder.name}.`).test(f.name))
-        ])
-      )
-      const innerNodes = new Set(
-        Object.values(folderContents)
-          .flat()
-          .map(f => f.name)
-      )
-      const foldersResult = await Promise.all(
-        Object.entries(folderContents)
-          .filter(([folderName, _]) => !innerNodes.has(folderName))
-          .map(async ([folderName, contents]) => [
-            folderName.replace('/', ''),
-            await this.zipEntriesToTree(
-              contents.map(node => {
-                const copy = cloneDeep(node)
-                copy.name = node.name.replace(new RegExp(`${folderName}`), '')
-                return copy
-              })
-            )
-          ])
-      )
-      const topLevelFiles = await Promise.all(
-        entryList
-          .filter(file => !file.isDirectory && !innerNodes.has(file.name))
-          .map(async node => new File([await node.blob()], node.name))
-      )
-      const filesResult = topLevelFiles
-        .filter(file => !/\.zip$/.test(file.name))
-        .map(file => [file.name, [file]])
-      const topLevelZips = topLevelFiles.filter(file =>
-        /\.zip$/.test(file.name)
-      )
-      const zipResult = await Promise.all(
-        topLevelZips.map(async node => {
-          const { entries } = await unzip(node)
-          const newEntryList = Object.values(entries)
-          return [node.name, await this.zipEntriesToTree(newEntryList)]
-        })
-      )
-      return Object.fromEntries([
-        ...filesResult,
-        ...zipResult,
-        ...foldersResult
-      ])
-    },
-    async fileListToTree(files) {
-      return Object.fromEntries(
-        await Promise.all(
-          files.map(async node => {
-            if (/\.zip$/.test(node.name)) {
-              const { entries } = await unzip(node)
-              const entryList = Object.values(entries)
-              return [node.name, await this.zipEntriesToTree(entryList)]
-            } else {
-              return [node.name, [node]]
-            }
-          })
-        )
-      )
-    },
-    itemifyFiles(tree) {
-      if (Array.isArray(tree)) {
-        return tree
-      } else {
-        return Object.entries(tree).flatMap(([file, node]) => {
-          if (Array.isArray(node)) {
-            const extension = file.match(/\.([\S]+)/)?.[1]
-            return {
-              id: this.idSpace++,
-              name: file,
-              file: node[0],
-              type: this.extension2filetype[extension] ?? 'file'
-            }
-          } else {
-            const inner = this.itemifyFiles(node)
-            const extension = file.match(/\.([\S]+)/)?.[1]
-            return {
-              id: this.idSpace++,
-              name: file,
-              children: inner,
-              type: this.extension2filetype[extension] ?? 'folder'
-            }
-          }
-        })
       }
     }
   }

--- a/components/UnitJsonViewer.vue
+++ b/components/UnitJsonViewer.vue
@@ -70,7 +70,6 @@ export default {
         this.error = true
       }
       this.loading = false
-      this.error = false
     },
     itemify(tree) {
       if (typeof tree !== 'object')
@@ -87,9 +86,10 @@ export default {
             icon: list[0].icon
           }
         } else {
+          const plural = list.length !== 1
           return {
             id: this.idSpace++,
-            name: `[list with ${list.length} items]`,
+            name: `[list with ${list.length} item${plural ? 's' : ''}]`,
             children: list,
             icon: mdiFormatListBulletedSquare
           }

--- a/utils/file.js
+++ b/utils/file.js
@@ -1,0 +1,154 @@
+import { unzip, setOptions } from 'unzipit'
+import workerURL from 'unzipit/dist/unzipit-worker.module.js'
+import {
+  mdiCodeJson,
+  mdiFile,
+  mdiFileImage,
+  mdiFilePdfBox,
+  mdiFolder,
+  mdiFolderZip,
+  mdiTable,
+  mdiTextBoxOutline,
+  mdiXml
+} from '@mdi/js'
+
+const filetype2icon = {
+  folder: mdiFolder,
+  zip: mdiFolderZip,
+  json: mdiCodeJson,
+  csv: mdiTable,
+  pdf: mdiFilePdfBox,
+  img: mdiFileImage,
+  file: mdiFile,
+  txt: mdiTextBoxOutline,
+  html: mdiXml
+}
+const extension2filetype = {
+  tar: 'zip',
+  js: 'json',
+  png: 'img',
+  jpeg: 'img',
+  jpg: 'img',
+  gif: 'img',
+  bmp: 'img',
+  webp: 'img',
+  pdf: 'pdf',
+  zip: 'zip',
+  json: 'json',
+  txt: 'txt',
+  html: 'html',
+  csv: 'csv',
+  tsv: 'csv'
+}
+
+setOptions({
+  workerURL,
+  numWorkers: 2
+})
+
+export default class FileTree {
+  constructor(uppyFiles, options) {
+    this.sortFiles = options?.sortFiles ?? true
+    return this.init(uppyFiles)
+  }
+
+  async init(uppyFiles) {
+    this.nNodes = 0
+    this.fileList = await this.extractZips(uppyFiles)
+    this.tree = this.makeTree(this.fileList)
+    return this
+  }
+
+  hasFile(filePath) {
+    return this.fileList.filter(file => file.name === filePath)
+  }
+
+  /**
+   * From a list of File objects that can potentially be zips, builds a flat
+   * list with the contents of the zips extracted and flattened.
+   * @param {File[]} files
+   * @returns {Promise<File[]>}
+   */
+  async extractZips(files) {
+    return (
+      await Promise.all(
+        files.map(async file => {
+          if (file.name.endsWith('.zip')) {
+            const { entries } = await unzip(file)
+            const innerFiles = await Promise.all(
+              Object.values(entries)
+                .filter(node => !node.isDirectory)
+                .map(
+                  async innerFile =>
+                    new File(
+                      [await innerFile.blob()],
+                      `${file.name}/${innerFile.name}`
+                    )
+                )
+            )
+            return await this.extractZips(innerFiles)
+          } else {
+            return file
+          }
+        })
+      )
+    ).flat()
+  }
+
+  makeTree(fileList) {
+    const tree = {}
+    fileList.forEach(file => {
+      const nodes = file.name.split('/')
+      nodes.reduce((acc, node, i) => {
+        if (i === nodes.length - 1) {
+          return (acc[node] = file)
+        } else {
+          return acc[node] || (acc[node] = {})
+        }
+      }, tree)
+    })
+    return tree
+  }
+
+  makeItems(tree) {
+    if (tree instanceof File) {
+      return tree
+    } else {
+      const items = Object.entries(tree).flatMap(([file, node]) => {
+        if (node instanceof File) {
+          const extension = file.match(/\.([\S]+)/)?.[1]
+          const type = extension2filetype[extension] ?? 'file'
+          return {
+            id: this.nNodes++,
+            name: file,
+            file: node,
+            type,
+            icon: filetype2icon[type] || mdiFile
+          }
+        } else {
+          const inner = this.makeItems(node)
+          const extension = file.match(/\.([\S]+)/)?.[1]
+          const type = extension2filetype[extension] ?? 'folder'
+          return {
+            id: this.nNodes++,
+            name: file,
+            children: inner,
+            type,
+            icon: filetype2icon[type] || mdiFolder
+          }
+        }
+      })
+      if (this.sortFiles) {
+        return items.sort((a, b) => {
+          for (const t of ['folder', 'zip']) {
+            if (a.type === t && b.type !== t) return -1
+            else if (a.type !== t && b.type === t) return 1
+          }
+          return a.name.localeCompare(b.name)
+        })
+      } else {
+        return items
+      }
+    }
+  }
+}

--- a/utils/file.js
+++ b/utils/file.js
@@ -50,7 +50,7 @@ setOptions({
  * A class that allows to extract the contents of zips, and allows building file trees and items for v-treeview.
  * Note that it doesn't actually load the content of the files, it just creates File objects that can than be read.
  */
-export default class FileTree {
+export default class FileManager {
   constructor(uppyFiles, options) {
     this.sortFiles = options?.sortFiles ?? true
     return this.init(uppyFiles)
@@ -59,7 +59,6 @@ export default class FileTree {
   async init(uppyFiles) {
     this.nNodes = 0
     this.fileList = await this.extractZips(uppyFiles)
-    this.tree = this.makeTree(this.fileList)
     return this
   }
 


### PR DESCRIPTION
Fixes bug #202 
Makes part of the refactoring needed for #203 

The logic of file extraction and building of a file tree has been moved from `components/UnitFileViewer.vue` to `utils/file.js`.
Created a class that could maybe handle everything file-related in the future.