### PR TITLE
feat: put back run buttons for custom pipelines

### DIFF
--- a/components/UnitCustomPipeline.vue
+++ b/components/UnitCustomPipeline.vue
@@ -32,8 +32,11 @@
 <script>
 import { processError } from '@/utils/utils'
 import FileManager from '~/utils/file-manager'
+import BaseButton from '~/components/BaseButton'
 
 export default {
+  name: 'UnitCustomPipeline',
+  components: { BaseButton },
   props: {
     fileManager: {
       type: FileManager,
@@ -59,25 +62,27 @@ export default {
     }
   },
   methods: {
-    async runPipeline() {
+    runPipeline() {
       this.message = ''
       this.error = false
       this.progress = true
-      try {
-        const { headers, items } = await this.customPipeline(
-          this.fileManager,
-          this.parameter
-        )
-        this.$emit('update', { headers, items })
-      } catch (error) {
-        console.error(error)
-        this.error = true
-        this.message = processError(error)
-        this.$emit('update', { error })
-      } finally {
-        this.status = true
-        this.progress = false
-      }
+      setTimeout(async () => {
+        try {
+          const { headers, items } = await this.customPipeline(
+            this.fileManager,
+            this.parameter
+          )
+          this.$emit('update', { headers, items })
+        } catch (error) {
+          console.error(error)
+          this.error = true
+          this.message = processError(error)
+          this.$emit('update', { error })
+        } finally {
+          this.status = true
+          this.progress = false
+        }
+      }, 1)
     }
   }
 }

--- a/components/UnitCustomPipeline.vue
+++ b/components/UnitCustomPipeline.vue
@@ -5,32 +5,26 @@
     </template>
 
     <template v-else>
-      <template v-if="parameterName">
-        <v-row>
-          <v-col cols="4" class="mx-auto">
-            <v-text-field
-              v-model="parameter"
-              :label="parameterName"
-              class="my-sm-2 mr-sm-2"
-            ></v-text-field>
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col align="center">
-            <base-button
-              text="Run"
-              icon="mdiStepForward"
-              class="ma-sm-2"
-              @click="runQuery"
-            />
-          </v-col>
-        </v-row>
-      </template>
-
-      <div v-if="progress" align="center">
-        <base-progress-circular class="mr-2" />
-        <span>Processing...</span>
-      </div>
+      <v-row v-if="parameterName">
+        <v-col cols="4" class="mx-auto">
+          <v-text-field
+            v-model="parameter"
+            :label="parameterName"
+            class="my-sm-2 mr-sm-2"
+          ></v-text-field>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col align="center">
+          <base-button
+            v-bind="{ progress, status, error }"
+            text="Run"
+            icon="mdiStepForward"
+            class="ma-sm-2"
+            @click="runPipeline"
+          />
+        </v-col>
+      </v-row>
     </template>
   </div>
 </template>
@@ -64,23 +58,8 @@ export default {
       parameter: ''
     }
   },
-  computed: {
-    disabled() {
-      return !this.fileManager.preprocessedTexts
-    }
-  },
-  watch: {
-    fileManager: {
-      immediate: true,
-      handler(_) {
-        if (!this.parameterName) {
-          this.runQuery()
-        }
-      }
-    }
-  },
   methods: {
-    async runQuery() {
+    async runPipeline() {
       this.message = ''
       this.error = false
       this.progress = true


### PR DESCRIPTION
I didn't manage to show the progress circle on the button like for sparql. It would be nice if someone knows why

Note: I removed this part

```
computed: {
    disabled() {
      return !this.fileManager.preprocessedTexts
    }
  }
```

for two reasons:
- It's always false because preprocessedTexts is initialized as an empty object
- Even if the value changed, I'm not sure if vue would detect it (see [reactivity in depth](https://vuejs.org/v2/guide/reactivity.html))