### PR TITLE
fix: #218 and various

### DIFF
--- a/components/TheAppBar.vue
+++ b/components/TheAppBar.vue
@@ -59,9 +59,7 @@
       </template>
       <div class="mt-6">
         <logo-img width="250" />
-        <the-data-experience-list
-          v-bind="{ enabledExperiences, disabledExperiences, big: false }"
-        />
+        <the-data-experience-list />
       </div>
     </v-navigation-drawer>
   </div>
@@ -73,27 +71,16 @@ import TheDataExperienceList from '~/components/TheDataExperienceList'
 
 export default {
   components: { TheDataExperienceList },
-  props: {
-    enabledExperiences: {
-      type: Array,
-      required: true
-    },
-    disabledExperiences: {
-      type: Array,
-      required: true
-    },
-    collaborator: {
-      type: Object,
-      default: () => {}
-    }
-  },
   data() {
     return {
       drawer: false
     }
   },
   computed: {
-    ...mapGetters(['manifest'])
+    ...mapGetters(['manifest', 'enabledExperiences', 'disabledExperiences']),
+    collaborator() {
+      return this.manifest(this.$route).collaborator
+    }
   }
 }
 </script>

--- a/components/TheDataExperienceList.vue
+++ b/components/TheDataExperienceList.vue
@@ -17,23 +17,18 @@
   </div>
 </template>
 <script>
+import { mapGetters } from 'vuex'
 import CardOrItemList from '~/components/CardOrItemList'
+
 export default {
   name: 'TheDataExperienceList',
   components: { CardOrItemList },
   props: {
     big: {
       type: Boolean,
-      required: true
-    },
-    enabledExperiences: {
-      type: Array,
-      required: true
-    },
-    disabledExperiences: {
-      type: Array,
-      required: true
+      default: false
     }
-  }
+  },
+  computed: mapGetters(['enabledExperiences', 'disabledExperiences'])
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,32 +1,22 @@
 <template>
   <v-app>
-    <the-app-bar v-bind="{ enabledExperiences, disabledExperiences }" />
+    <the-app-bar />
     <v-main>
       <v-container class="mt-5">
         <v-row>
           <v-col align="center">
             <h2>
               <a
-                :href="`${
-                  collaborator.url || 'https://hestialabs.org/'
-                }#newsletter`"
+                :href="newsletterURL"
                 target="_blank"
                 rel="noreferrer noopener"
               >
-                Subscribe to
-                {{
-                  collaborator.title
-                    ? `${collaborator.title}${
-                        collaborator.title.endsWith('s') ? "'" : "'s"
-                      }`
-                    : "HestiaLabs'"
-                }}
-                newsletter!
+                {{ newsletterMessage }}
               </a>
             </h2>
           </v-col>
         </v-row>
-        <NuxtChild v-bind="{ enabledExperiences, disabledExperiences }" />
+        <Nuxt />
         <v-snackbar
           v-model="snackbar"
           content-class="v-snack__content-online-status"
@@ -83,19 +73,17 @@ export default {
   computed: {
     ...mapGetters(['manifest']),
     collaborator() {
-      if (this.$route.params.key) {
-        const { collaborator } = this.manifest(this.$route)
-        return collaborator || {}
-      }
-      return {}
+      const { collaborator = {} } = this.manifest(this.$route)
+      return collaborator
     },
-    enabledExperiences() {
-      return this.$store.getters.manifests.filter(({ disabled }) => !disabled)
+    newsletterURL() {
+      const { url = 'https://hestialabs.org/' } = this.collaborator
+      return `${url}#newsletter`
     },
-    disabledExperiences() {
-      return this.$store.getters.manifests
-        .filter(({ disabled }) => disabled)
-        .map(o => (o.key === 'other' ? { ...o, disabled: false } : o))
+    newsletterMessage() {
+      const { title = 'HestiaLabs' } = this.collaborator
+      const genitiveCaseEnding = title.endsWith('s') ? '’' : '’s'
+      return `Subscribe to ${title}${genitiveCaseEnding} newsletter!`
     }
   },
   watch: {
@@ -104,9 +92,6 @@ export default {
       // changing timeout property resets the timeout
       this.timeout = isOffline ? 5001 : 5000
     }
-  },
-  beforeCreate() {
-    this.$store.dispatch('loadConfig')
   },
   mounted() {
     if (!window.Worker) {

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -15,7 +15,7 @@ export default {
   props: {
     error: {
       type: Object,
-      default: null
+      default: () => ({})
     }
   },
   head() {
@@ -25,9 +25,10 @@ export default {
   },
   computed: {
     title() {
-      return this.error.statusCode === 404
-        ? '404 Not Found'
-        : 'An error occurred'
+      return (
+        this.error.message ||
+        (this.error.statusCode === 404 ? '404 Not Found' : 'An error occurred')
+      )
     }
   }
 }

--- a/manifests/index.js
+++ b/manifests/index.js
@@ -225,4 +225,11 @@ Object.entries(manifests).forEach(([key, val]) => {
   }
 })
 
-export default manifests
+export const config = require(`@/config/${process.env.configName}.json`)
+
+// keep only experiences declared in the config
+const manifestsFiltered = Object.fromEntries(
+  Object.entries(manifests).filter(([k, v]) => config.experiences.includes(k))
+)
+
+export default manifestsFiltered

--- a/pages/_key.vue
+++ b/pages/_key.vue
@@ -37,7 +37,7 @@ import { mapState, mapGetters } from 'vuex'
 export default {
   middleware({ store, params, error }) {
     if (
-      !store.getters.enabledExperiences.map(x => x.key).includes(params.key)
+      !store.getters.enabledExperiences.find(x => x.key === params.key)
     ) {
       return error({ statusCode: 404, message: 'Experience Not Found' })
     }

--- a/pages/_key.vue
+++ b/pages/_key.vue
@@ -36,7 +36,9 @@ import { mapState, mapGetters } from 'vuex'
 
 export default {
   middleware({ store, params, error }) {
-    if (!store.state.config.experiences.includes(params.key)) {
+    if (
+      !store.getters.enabledExperiences.map(x => x.key).includes(params.key)
+    ) {
       return error({ statusCode: 404, message: 'Experience Not Found' })
     }
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,27 +1,11 @@
 <template>
-  <the-data-experience-list
-    v-bind="{
-      enabledExperiences,
-      disabledExperiences,
-      big: $vuetify.breakpoint.smAndUp
-    }"
-  />
+  <the-data-experience-list :big="$vuetify.breakpoint.smAndUp" />
 </template>
 <script>
 import TheDataExperienceList from '~/components/TheDataExperienceList'
 
 export default {
-  components: { TheDataExperienceList },
-  props: {
-    enabledExperiences: {
-      type: Array,
-      required: true
-    },
-    disabledExperiences: {
-      type: Array,
-      required: true
-    }
-  }
+  components: { TheDataExperienceList }
 }
 </script>
 <style>

--- a/store/index.js
+++ b/store/index.js
@@ -1,15 +1,12 @@
-import manifestMap from '@/manifests'
+import manifestMap, { config } from '@/manifests'
 
 export const state = () => ({
-  config: { notLoaded: true },
+  config,
   manifestMap,
   power: false
 })
 
 export const getters = {
-  config(state) {
-    return state.config
-  },
   manifests(state) {
     const experiences = state.config?.experiences || []
     const activeManifests = experiences
@@ -23,6 +20,14 @@ export const getters = {
     // playground is not available in default mode
     return activeManifests.filter(m => m.key !== 'playground')
   },
+  enabledExperiences(state, getters) {
+    return getters.manifests.filter(({ disabled }) => !disabled)
+  },
+  disabledExperiences(state, getters) {
+    return getters.manifests
+      .filter(({ disabled }) => disabled)
+      .map(o => (o.key === 'other' ? { ...o, disabled: false } : o))
+  },
   keys(state, getters) {
     return getters.manifests.map(({ key }) => key)
   },
@@ -30,29 +35,12 @@ export const getters = {
   manifest:
     state =>
     ({ params: { key } }) => {
-      // return state.manifests.find(m => m.key === key)
-      return state.manifestMap[key]
+      return state.manifestMap[key] || {}
     }
 }
 
 export const mutations = {
-  updateConfig(state, config) {
-    state.config = config
-  },
   updatePower(state, power) {
     state.power = power
-  }
-}
-
-export const actions = {
-  async loadConfig({ commit }) {
-    // AK: Not sure if webpack's import is the best solution.
-    // It's faster for server side rendering, which we're not using.
-    // Is it also faster on the client? I don't see an http request for it.
-    // We could also put the config in the static directory
-    // and use window.fetch (breaks ssr) or axios
-    // https://github.com/nuxt/nuxt.js/issues/123#issuecomment-272246782
-    const config = await import(`~/config/${process.env.configName}.json`)
-    commit('updateConfig', config)
   }
 }


### PR DESCRIPTION
* fixed #218, added a navigation guard middleware to `pages/_key.vue`
* moved `enabledExperiences`/`disabledExperiences` to the Vuex store
* improved newsletter code, better to keep code in `<script>` and `<template>` as clean as possible
* changed config loading to load the config in `manifests/index.js`
* added experience filter in `manifests/index.js` based on the config