### PR TITLE
feat: consent form upgrade

### DIFF
--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -88,7 +88,7 @@ export default {
   watch: {
     includedResults: {
       deep: true,
-      handler(includedResults) {
+      handler() {
         this.resetStatus()
       }
     }
@@ -166,8 +166,13 @@ export default {
           this.sentError = true
         })
     },
-    updateConsent({ index, selected }) {
-      this.consent[index].selected = selected
+    updateConsent({ index, selected, value }) {
+      const section = this.consent[index]
+      if (section.type === 'checkbox' || section.type === 'radio') {
+        section.selected = selected
+      } else if (section.type === 'input') {
+        section.value = value
+      }
       this.resetStatus()
     },
     resetStatus() {

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <h2>{{ section.title }}</h2>
+    <h2 v-if="section.title">{{ section.title }}</h2>
 
-    <p>
+    <p v-if="section.description">
       {{ section.description }}
     </p>
 
@@ -32,6 +32,23 @@
         @change="updateConsent"
       />
     </template>
+
+    <template v-if="section.type === 'input'">
+      <VTextField
+        v-if="readonly"
+        dense
+        :readonly="readonly"
+        :value="section.value"
+        :label="section.name"
+      ></VTextField>
+      <VTextField
+        v-else
+        v-model="value"
+        dense
+        :label="section.name"
+        @change="updateConsent"
+      ></VTextField>
+    </template>
   </div>
 </template>
 
@@ -53,12 +70,17 @@ export default {
   },
   data() {
     return {
-      selected: this.section.selected
+      selected: this.section.selected,
+      value: ''
     }
   },
   methods: {
-    updateConsent(event) {
-      this.$emit('change', { index: this.index, selected: this.selected })
+    updateConsent() {
+      this.$emit('change', {
+        index: this.index,
+        selected: this.selected,
+        value: this.value
+      })
     }
   }
 }

--- a/components/unit/files/UnitFiles.vue
+++ b/components/unit/files/UnitFiles.vue
@@ -113,9 +113,6 @@ export default {
     },
     disabled() {
       return this.filesEmpty
-    },
-    saveFiles() {
-      return this.$store.state.config.saveFiles
     }
   },
   watch: {

--- a/config/README.md
+++ b/config/README.md
@@ -13,34 +13,39 @@ This directory contains the configuration files linked to each deployement. They
     */
   "publicKey": "29500a8814ffbfbb3fda7e9854ab8319e349dd50c1fe018ac342300d52f47626",
   /**
-    * The content of the consent form. Each section has:
+    * The content of the consent form. Each section can have:
     * - A title
     * - A description
-    * - A type (Either 'radio' or 'checkbox' or nothing)
-    * - An array of options
-    * - A pre-selected answer (or an array of pre-selected answers in the case of checkboxes).
-    *   Use an empty string or empty array for no pre-selection.
+    * - A type (Either 'radio' or 'checkbox' or 'input')
+    *   - For type 'radio': an array of options and a pre-selected answer (use the empty string for no pre-selection)
+    *   - For type 'checkbox': an array of options and an array of pre-selected answers (use the empty array for no pre-selection)
+    * - For type 'input': the name (label) of the input field
     * @type Array
     */
   "consent": [
     {
-      "title": "Interesting title 1",
-      "description": "Lorem ipsum"
+      "title": "Introduction",
+      "description": "This is an example consent form."
     },
     {
-      "title": "Interesting title 2",
-      "description": "Lorem ipsum",
+      "description": "Please input some information",
+      "type": "input",
+      "name": "e-mail",
+    },
+    {
+      "title": "Radio buttons",
+      "description": "Please select one option.",
       "type": "radio",
-      "options": ["A", "B", "C"],
+      "options": ["A", "B"],
       "selected": "A"
     },
     {
-      "title": "Interesting title 3",
-      "description": "Lorem ipsum",
+      "title": "Checkboxes",
+      "description": "Please select all options that apply.",
       "type": "checkbox",
-      "options": ["A", "B", "C"],
+      "options": ["X", "Y", "Z"],
       "selected": []
-    },
+    }
   ]
 }
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -8,11 +8,6 @@ This directory contains the configuration files linked to each deployement. They
     */
   "experiences": ["facebook", "google", "twitter"],
   /**
-    * Activate/deactivate the automatic local saving of data files, and show/hide the "cache" buttons.
-    * @type Boolean
-    */
-  "saveFiles": false,
-  /**
     * The public key used to encrypt the zip containing the consent log and results.
     * @type String
     */

--- a/config/config.json
+++ b/config/config.json
@@ -29,6 +29,11 @@
       "description": "This is an example consent form."
     },
     {
+      "description": "Please input some information.",
+      "type": "input",
+      "name": "e-mail"
+    },
+    {
       "title": "Radio buttons",
       "description": "Please select one option.",
       "type": "radio",

--- a/config/config.json
+++ b/config/config.json
@@ -22,7 +22,6 @@
     "other"
   ],
   "hashtags": ["dataprivacy", "hestialabs"],
-  "saveFiles": true,
   "publicKey": "29500a8814ffbfbb3fda7e9854ab8319e349dd50c1fe018ac342300d52f47626",
   "consent": [
     {

--- a/config/digipower.json
+++ b/config/digipower.json
@@ -22,6 +22,5 @@
     "explorer"
   ],
   "hashtags": ["dataprivacy", "hestialabs", "digipower"],
-  "saveFiles": false,
   "publicKey": "710decd4e26312d3e7b02854fefe53cc1ef8d7b25e8f99bc6df956c1a526e144"
 }

--- a/config/workshop.json
+++ b/config/workshop.json
@@ -1,5 +1,4 @@
 {
   "experiences": ["facebook", "twitter", "tinder", "ad-radar", "amazon", "apple", "google", "spotify", "youtube", "other"],
-  "hashtags": ["dataprivacy", "hestialabs"],
-  "saveFiles": false
+  "hashtags": ["dataprivacy", "hestialabs"]
 }


### PR DESCRIPTION
Added support for text input fields in the consent form. Also removed `saveFiles` parameter that is no longer usable since the `fileManager` refactoring.