### PR TITLE
fix: unitvegaviz and chartview dont crash when theres no data

### DIFF
--- a/components/chart/ChartView.vue
+++ b/components/chart/ChartView.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
-    <component :is="component" v-if="isValid" :values="values" />
-    <i v-else>data in this format cannot be displayed by this visualization</i>
+    <component :is="component" v-if="isValid && !isEmpty" :values="values" />
+    <i v-else-if="isValid">No data found</i>
+    <i v-else>Data in this format cannot be displayed by this visualization</i>
   </div>
 </template>
 
@@ -19,6 +20,10 @@ function isDataValid(data) {
   )
 }
 
+function isDataEmpty(data) {
+  return data.items.length === 0
+}
+
 export default {
   props: {
     data: {
@@ -33,6 +38,9 @@ export default {
   computed: {
     isValid() {
       return isDataValid(this.data)
+    },
+    isEmpty() {
+      return isDataEmpty(this.data)
     },
     values() {
       return this.data.items || {}

--- a/components/unit/UnitVegaViz.vue
+++ b/components/unit/UnitVegaViz.vue
@@ -110,9 +110,11 @@ export default {
       this.draw()
     }
   },
-  async mounted() {
-    if (this.$refs.graph) this.width = this.$refs.graph.offsetWidth
-    if (this.isValid && !this.isEmpty) await this.draw()
+  mounted() {
+    this.width = this.$refs.graph?.offsetWidth ?? 0
+    if (this.isValid && !this.isEmpty) {
+      this.draw()
+    }
   },
   methods: {
     async draw() {


### PR DESCRIPTION
Addressing #241 

The problem is related to how `UnitVegaViz` and `ChartView` handle the given data when it's malformed or empty.
Changes:
- the error message now depends on whether the data is in the correct shape or if it is empty
- removed references to the vega graph when it doesn't exist in `UnitVegaViz`

Please give feedback if you see another way to solve this issue!