### PR TITLE
feat: add download button in file explorer 

### DIFF
--- a/components/base/button/download/BaseButtonDownload.vue
+++ b/components/base/button/download/BaseButtonDownload.vue
@@ -11,6 +11,10 @@ export default {
       type: String,
       required: true
     },
+    filename: {
+      type: String,
+      default: undefined
+    },
     extension: {
       type: String,
       default: defaultExtension,
@@ -25,7 +29,7 @@ export default {
   },
   computed: {
     download() {
-      return `results.${this.extension}`
+      return this.filename ?? `results.${this.extension}`
     }
   },
   watch: {

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -31,7 +31,16 @@
             <VCardTitle class="justify-center">File details</VCardTitle>
             <VCardText>
               <template v-if="selectedItem">
-                <p>Exploring file {{ selectedItem.filename }}</p>
+                <p>
+                  <span class="mr-2">
+                    Exploring file <strong>{{ selectedItem.filename }}</strong>
+                  </span>
+                  <BaseButtonDownload
+                    small
+                    :href="path"
+                    :filename="selectedItem.filename"
+                  />
+                </p>
                 <component
                   :is="componentForType"
                   v-bind="{ fileManager, filename: selectedItem.filename }"
@@ -71,6 +80,13 @@ export default {
     }
   },
   computed: {
+    path() {
+      // TODO avoid code duplication with viewer/mixin-path
+      // maybe by setting path as an attribute on every viewer
+      return URL.createObjectURL(
+        this.fileManager.fileDict[this.selectedItem.filename]
+      )
+    },
     fileType() {
       // @fileType should match the postfix of the Vue component name
       return this.selectedItem?.type


### PR DESCRIPTION
The file viewer for unknown types allows to download files only in firefox. Chrome tries to display even binary files.

This pull request adds a download option for all files, including those of a known type.

It contributes to address the feature request hestiaAI/digipower-data-experiences#79