### PR TITLE
fix: file explorer does not show an empty file corresponding to the folder itself

### DIFF
--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -283,7 +283,7 @@ export default class FileManager {
   static async extractZips(files) {
     return (
       await Promise.all(
-        files.map(async file => {
+        files.flatMap(async file => {
           if (file.name.endsWith('.zip')) {
             const { entries } = await unzip(file)
             const innerFiles = await Promise.all(
@@ -298,8 +298,10 @@ export default class FileManager {
                 )
             )
             return await this.extractZips(innerFiles)
+          } else if (file.name.endsWith('/')) {
+            return []
           } else {
-            return file
+            return [file]
           }
         })
       )


### PR DESCRIPTION
For some reason, in some zip archives, the folders are encoded as a file, which messes up the file explorer tree, so we observe empty files like this one:
![image](https://user-images.githubusercontent.com/16099301/143834238-4885c49d-cb26-442a-a5fa-a78d62839ac5.png)
After the fix, this file doesn't appear:
![image](https://user-images.githubusercontent.com/16099301/143834054-dda2fcd5-5bae-466d-9cc8-7cf3034fb916.png)
