### PR TITLE
fix: the download button apply for the additional columns that we add/transform ourselves

### DIFF
--- a/components/unit/filterable-table/UnitFilterableTable.vue
+++ b/components/unit/filterable-table/UnitFilterableTable.vue
@@ -97,8 +97,9 @@ export default {
         this.error = false
         try {
           const headers = this.headers.map(h => h.text)
+          const filteredItems = this.$refs.tableRef.$children[0].filteredItems
           // Change the items keys to match the headers
-          const itemsWithHeader = this.items.map(i =>
+          const itemsWithHeader = filteredItems.map(i =>
             this.headers.reduce((o, h) => ({ ...o, [h.text]: i[h.value] }), {})
           )
           // update the data

--- a/components/unit/filterable-table/UnitFilterableTable.vue
+++ b/components/unit/filterable-table/UnitFilterableTable.vue
@@ -97,8 +97,12 @@ export default {
         this.error = false
         try {
           const headers = this.headers.map(h => h.text)
+          // Change the items keys to match the headers
+          const itemsWithHeader = this.items.map(i =>
+            this.headers.reduce((o, h) => ({ ...o, [h.text]: i[h.value] }), {})
+          )
           // update the data
-          this.csvData = await writeToString(this.items, { headers })
+          this.csvData = await writeToString(itemsWithHeader, { headers })
           // wait until DOM is updated, i.e. the href attribute (see BaseButtonDownload.vue)
           await this.$nextTick()
           // click the anchor manually -> event.isTrusted === false


### PR DESCRIPTION
Related to https://github.com/hestiaAI/digipower-data-experiences/issues/85
Previously, the download button used the raw csv and not the actual displayed data.