### PR TITLE
fix: various fixes regarding file upload

### DIFF
--- a/components/the-data-experience/TheDataExperience.vue
+++ b/components/the-data-experience/TheDataExperience.vue
@@ -134,6 +134,7 @@ export default {
         'isGenericViewer',
         'showDataExplorer',
         'files',
+        'multiple',
         'allowMissingFiles',
         'sparql',
         'sql',

--- a/components/the-data-experience/TheDataExperienceDefault.vue
+++ b/components/the-data-experience/TheDataExperienceDefault.vue
@@ -76,6 +76,7 @@ export default {
     isGenericViewer: Boolean,
     showDataExplorer: Boolean,
     files: Array,
+    multiple: Boolean,
     preprocessors: Object,
     allowMissingFiles: Boolean,
     sparql: Object,
@@ -123,7 +124,7 @@ export default {
       this.progress = true
       const start = new Date()
 
-      await this.fileManager.init(uppyFiles)
+      await this.fileManager.init(uppyFiles, this.multiple)
       let processedFiles
       try {
         processedFiles = await this.fileManager.preprocessFiles(this.files)

--- a/components/unit/files/UnitFiles.vue
+++ b/components/unit/files/UnitFiles.vue
@@ -81,12 +81,10 @@ export default {
     const config = {
       debug: false,
       allowMultipleUploads: this.multiple,
-      restrictions: this.extensions
-        ? {}
-        : {
-            maxNumberOfFiles: this.multiple ? null : 1,
-            allowedFileTypes: this.extensions
-          }
+      restrictions: {
+        maxNumberOfFiles: this.multiple ? null : 1,
+        allowedFileTypes: this.extensions.length > 0 ? this.extensions : null
+      }
     }
     return {
       uppy: new Uppy(config),
@@ -109,7 +107,9 @@ export default {
     },
     extensionsMessage() {
       const exts = this.extensions.join(', ')
-      return `Allowed file types: ${exts}`
+      return `${this.multiple ? 'Multiple files' : 'One file'} allowed (${
+        exts.length > 0 ? exts : 'any extension'
+      })`
     },
     disabled() {
       return this.filesEmpty
@@ -163,7 +163,7 @@ export default {
         proudlyDisplayPoweredByUppy: false,
         theme: 'light',
         width: 550,
-        height: 400
+        height: 200
       })
       // allow dropping files anywhere on the page
       .use(DropTarget, { target: document.body })

--- a/manifests/experiences/apple/apple.json
+++ b/manifests/experiences/apple/apple.json
@@ -2,6 +2,7 @@
   "title": "Apple",
   "icon": "apple.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/bookbeat/bookbeat.json
+++ b/manifests/experiences/bookbeat/bookbeat.json
@@ -2,6 +2,7 @@
   "title": "BookBeat",
   "icon": "bookbeat.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/finnair/finnair.json
+++ b/manifests/experiences/finnair/finnair.json
@@ -2,6 +2,7 @@
   "title": "FinnAir",
   "icon": "finnair.jpg",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/gigantti/gigantti.json
+++ b/manifests/experiences/gigantti/gigantti.json
@@ -2,6 +2,7 @@
   "title": "Gigantti",
   "icon": "gigantti.jpg",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/helsingin-sanomat/helsingin-sanomat.json
+++ b/manifests/experiences/helsingin-sanomat/helsingin-sanomat.json
@@ -2,6 +2,7 @@
   "title": "Helsingin Sanomat",
   "icon": "helsingin-sanomat.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/hsl/hsl.json
+++ b/manifests/experiences/hsl/hsl.json
@@ -2,6 +2,7 @@
   "title": "HSL",
   "icon": "hsl.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/k-ryhma/k-ryhma.json
+++ b/manifests/experiences/k-ryhma/k-ryhma.json
@@ -2,6 +2,7 @@
   "title": "K-Ryhmä",
   "icon": "k-ryhma.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/lime/lime.json
+++ b/manifests/experiences/lime/lime.json
@@ -2,6 +2,7 @@
   "title": "Lime",
   "icon": "lime.jpg",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/linkedin/linkedin.json
+++ b/manifests/experiences/linkedin/linkedin.json
@@ -2,6 +2,7 @@
   "title": "LinkedIn",
   "icon": "linkedin.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/netflix/netflix.json
+++ b/manifests/experiences/netflix/netflix.json
@@ -2,6 +2,7 @@
   "title": "Netflix",
   "icon": "netflix.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/s-ryhma/s-ryhma.json
+++ b/manifests/experiences/s-ryhma/s-ryhma.json
@@ -2,6 +2,7 @@
   "title": "S-Ryhmä",
   "icon": "s-ryhma.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/signal/signal.json
+++ b/manifests/experiences/signal/signal.json
@@ -2,6 +2,7 @@
   "title": "Signal",
   "icon": "signal.svg",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/spotify/spotify.json
+++ b/manifests/experiences/spotify/spotify.json
@@ -2,6 +2,7 @@
   "title": "Spotify",
   "icon": "spotify.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/voi/voi.json
+++ b/manifests/experiences/voi/voi.json
@@ -2,6 +2,7 @@
   "title": "Voi",
   "icon": "voi.jpg",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/whatsapp/whatsapp.json
+++ b/manifests/experiences/whatsapp/whatsapp.json
@@ -2,6 +2,7 @@
   "title": "Whatsapp",
   "icon": "whatsapp.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/manifests/experiences/wolt/wolt.json
+++ b/manifests/experiences/wolt/wolt.json
@@ -2,6 +2,7 @@
   "title": "Wolt",
   "icon": "wolt.png",
   "ext": "all",
+  "multiple": true,
   "isGenericViewer": true,
   "showDataExplorer": true,
   "defaultView": [

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -92,13 +92,13 @@ export default class FileManager {
    * @param {File[]} uppyFiles
    * @returns {Promise<FileManager>}
    */
-  async init(uppyFiles) {
+  async init(uppyFiles, multiple) {
     this.fileList = await FileManager.extractZips(uppyFiles)
     const filePairs = this.fileList.map(f => [f.name, f])
-    if (filePairs.length === 1) {
-      this.fileDict = FileManager.removeTopmostFilenames(filePairs)
-    } else {
+    if (multiple) {
       this.fileDict = Object.fromEntries(filePairs)
+    } else {
+      this.fileDict = FileManager.removeTopmostFilenames(filePairs)
     }
     this.setInitialValues()
     return this

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -94,9 +94,12 @@ export default class FileManager {
    */
   async init(uppyFiles) {
     this.fileList = await FileManager.extractZips(uppyFiles)
-    this.fileDict = FileManager.removeTopmostFilenames(
-      this.fileList.map(f => [f.name, f])
-    )
+    const filePairs = this.fileList.map(f => [f.name, f])
+    if (filePairs.length === 1) {
+      this.fileDict = FileManager.removeTopmostFilenames(filePairs)
+    } else {
+      this.fileDict = Object.fromEntries(filePairs)
+    }
     this.setInitialValues()
     return this
   }


### PR DESCRIPTION
Changes: 

- Fix `file-manager` for multiple files (now it doesn't remove the topmost path element when there are multiple files)
- Fix Uppy restrictions
- Generic experiences are configured to allow multiple files, others are not
- Change information message about file extensions and number of files
- Uppy box is a bit smaller

Related to:
- https://github.com/hestiaAI/digipower-data-experiences/issues/62
- https://github.com/hestiaAI/digipower-data-experiences/issues/59 point 6 within experiences