### PR TITLE
feat: add form version control

### DIFF
--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -49,6 +49,10 @@ import JSZip from 'jszip'
 
 const _sodium = require('libsodium-wrappers')
 
+// In the case of changes that would break the import, this version number must be incremented
+// and the function versionCompatibilityHandler of import.vue must be able to handle previous versions.
+const VERSION = 1
+
 export default {
   props: {
     allResults: {
@@ -161,7 +165,8 @@ export default {
       this.timestamp = Date.now()
       const experience = {
         key: manifest.key,
-        timestamp: this.timestamp
+        timestamp: this.timestamp,
+        version: VERSION
       }
       zip.file('experience.json', JSON.stringify(experience))
 

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -52,6 +52,12 @@
             }}</VListItemSubtitle>
           </VListItemContent>
         </VListItem>
+        <VListItem two-line>
+          <VListItemContent>
+            <VListItemTitle>Version</VListItemTitle>
+            <VListItemSubtitle>{{ experience.version }}</VListItemSubtitle>
+          </VListItemContent>
+        </VListItem>
       </VCard>
 
       <!-- Consent log -->
@@ -241,6 +247,9 @@ export default {
         return
       }
 
+      // Version compatibility
+      this.versionCompatibilityHandler()
+
       this.handleEnd()
     },
     async generateKeys() {
@@ -255,6 +264,16 @@ export default {
       zip.file('secret-key.txt', sk)
       const content = await zip.generateAsync({ type: 'blob' })
       FileSaver.saveAs(content, 'keys.zip')
+    },
+    /* Transform the imported zip to make it compatible with the current version */
+    versionCompatibilityHandler() {
+      if (!('version' in this.experience)) {
+        this.experience.version = 1
+      }
+      const version = this.experience.version
+      if (version === 1) {
+        // Nothing to do for now
+      }
     }
   }
 }


### PR DESCRIPTION
This is a basic and manual way of dealing with the fact that the structure of the forms may change over time, which would break the import of older ZIPs

https://github.com/hestiaAI/digipower-data-experiences/issues/92