### PR TITLE
style: change file explorer layout

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,8 +39,7 @@ module.exports = {
       'PascalCase',
       {
         registeredComponentsOnly: false,
-        // https://github.com/vuejs/eslint-plugin-vue/issues/1722
-        ignores: ['/^component|client-only|keep-alive$/']
+        ignores: ['component', 'client-only', 'keep-alive']
       }
     ]
   }

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -1,58 +1,79 @@
 <template>
-  <VCard class="pa-2 my-6" min-height="500px" height="auto">
+  <VCard class="pa-2 my-6 explorer" :min-height="height" height="auto">
+    <VNavigationDrawer
+      ref="drawer"
+      :mini-variant.sync="mini"
+      :mini-variant-width="miniWidth"
+      absolute
+      permanent
+      width="100%"
+    >
+      <template #prepend>
+        <VListItem class="px-2">
+          <VBtn icon @click.stop="mini = !mini">
+            <VIcon>$vuetify.icons.mdiFileSearch</VIcon>
+          </VBtn>
+
+          <VListItemTitle class="mx-4">File Explorer</VListItemTitle>
+
+          <VBtn icon @click.stop="mini = !mini">
+            <VIcon>$vuetify.icons.mdiChevronLeft</VIcon>
+          </VBtn>
+        </VListItem>
+      </template>
+
+      <div :style="drawerMiniFileLabelStyle" class="drawer-mini-file-label">
+        <div>{{ selectedItem.name }}</div>
+      </div>
+
+      <div :class="miniWidthPaddingLeftClass">
+        <VTextField
+          v-model="search"
+          label="Search files"
+          placeholder="Type..."
+          clearable
+          hide-details
+          prepend-icon="$vuetify.icons.mdiMagnify"
+          class="my-4 pr-3"
+          style="max-width: 500px"
+          outlined
+          dense
+        />
+        <VTreeview
+          dense
+          open-on-click
+          activatable
+          return-object
+          transition
+          rounded
+          :search="search"
+          :items="fileManager.getTreeItems()"
+          @update:active="setSelectedItem"
+        >
+          <template #prepend="{ item }">
+            <VIcon>
+              {{ item.icon }}
+            </VIcon>
+          </template>
+        </VTreeview>
+      </div>
+    </VNavigationDrawer>
     <VCardTitle class="justify-center"> Explore your files </VCardTitle>
     <VCardText class="align-center">
-      <VNavigationDrawer
-        expand-on-hover
-        permanent
-        absolute
-        :mini-variant-width="drawerWidth"
-        width="auto"
-      >
-        <VList>
-          <VListItem>
-            <VListItemTitle class="py-2">File hierarchy</VListItemTitle>
-          </VListItem>
-          <VListItem>
-            <VTreeview
-              dense
-              open-on-click
-              activatable
-              return-object
-              transition
-              rounded
-              :items="fileManager.getTreeItems()"
-              @update:active="setSelectedItem"
-            >
-              <template #prepend="{ item }">
-                <VIcon>
-                  {{ item.icon }}
-                </VIcon>
-              </template>
-            </VTreeview>
-          </VListItem>
-        </VList>
-      </VNavigationDrawer>
-      <div :style="{ 'margin-left': drawerWidth }">
-        <template v-if="selectedItem">
-          <p>
-            <span class="mr-2">
-              Exploring file <strong>{{ selectedItem.filename }}</strong>
-            </span>
-            <BaseButtonDownload
-              small
-              :href="path"
-              :filename="selectedItem.filename"
-            />
-          </p>
+      <div :class="miniWidthPaddingLeftClass">
+        <template v-if="filename">
+          <div class="mr-2">
+            Exploring file <strong>{{ filename }}</strong>
+          </div>
+          <BaseButtonDownload small :href="path" :filename="filename" />
           <component
             :is="componentForType"
-            v-bind="{ fileManager, filename: selectedItem.filename }"
+            v-bind="{ fileManager, filename }"
             v-if="supportedTypes.has(fileType)"
           />
           <UnitFileExplorerViewerUnknown
             v-else
-            v-bind="{ fileManager, filename: selectedItem.filename }"
+            v-bind="{ fileManager, filename }"
           />
         </template>
         <template v-else>
@@ -76,23 +97,26 @@ export default {
   },
   data() {
     return {
-      selectedItem: null,
+      selectedItem: {},
       supportedTypes: new Set(['json', 'csv', 'pdf', 'img', 'html', 'txt']),
-      drawer: true,
-      drawerWidth: '150px'
+      mini: true,
+      miniWidth: 48,
+      search: '',
+      height: 500
     }
   },
   computed: {
-    path() {
-      // TODO avoid code duplication with viewer/mixin-path
-      // maybe by setting path as an attribute on every viewer
-      return URL.createObjectURL(
-        this.fileManager.fileDict[this.selectedItem.filename]
-      )
-    },
     fileType() {
       // @fileType should match the postfix of the Vue component name
       return this.selectedItem?.type
+    },
+    filename() {
+      return this.selectedItem?.filename || ''
+    },
+    path() {
+      // TODO avoid code duplication with viewer/mixin-path
+      // maybe by setting path as an attribute on every viewer
+      return URL.createObjectURL(this.fileManager.fileDict[this.filename])
     },
     componentForType() {
       const { fileType } = this
@@ -104,16 +128,66 @@ export default {
         import(
           `~/components/unit/file-explorer/viewer/UnitFileExplorerViewer${postfix}`
         )
+    },
+    miniWidthPaddingLeftClass() {
+      return `pl-${parseInt(this.miniWidth / 4)}`
+    },
+    drawerMiniFileLabelStyle() {
+      const { miniWidth: w, height: h } = this
+      const px = `${w}px`
+      return {
+        minWidth: px,
+        height: px,
+        bottom: `-${w - 18}px`,
+        maxWidth: `${h - w - 20}px`
+      }
+    }
+  },
+  watch: {
+    mini(mini) {
+      // hide scrollbar in mini variant of drawer
+      const overflowY = mini ? 'hidden' : 'visible'
+      this.$refs.drawer.$el.children[1].style.overflowY = overflowY
     }
   },
   methods: {
-    setSelectedItem(array) {
-      const item = array[0]
-      const containers = new Set(['folder', 'zip'])
-      if (!containers.has(item?.type)) {
-        this.selectedItem = item
+    setSelectedItem([item]) {
+      // item might be undefined (when unselecting)
+      if (item) {
+        // close drawer when file is selected
+        this.mini = true
+        const containers = new Set(['folder', 'zip'])
+        if (!containers.has(item?.type)) {
+          this.selectedItem = item
+        }
       }
     }
   }
 }
 </script>
+
+<style>
+.drawer-mini-file-label {
+  transform: rotate(270deg);
+  transform-origin: top left;
+
+  display: flex;
+  align-items: center;
+
+  position: absolute;
+}
+
+.drawer-mini-file-label > div {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.explorer__content {
+  max-height: 500px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+</style>

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -1,63 +1,64 @@
 <template>
-  <VCard class="pa-2 my-6">
-    <VCardTitle class="justify-center">Explore your files</VCardTitle>
-    <VCardText>
-      <VRow>
-        <VCol cols="3">
-          <VCard class="pa-2 my-6">
-            <VCardTitle class="justify-center">File hierarchy</VCardTitle>
-            <VCardText>
-              <VTreeview
-                dense
-                open-on-click
-                activatable
-                rounded
-                return-object
-                transition
-                :items="fileManager.getTreeItems()"
-                @update:active="setSelectedItem"
-              >
-                <template #prepend="{ item }">
-                  <VIcon>
-                    {{ item.icon }}
-                  </VIcon>
-                </template>
-              </VTreeview>
-            </VCardText>
-          </VCard>
-        </VCol>
-        <VCol cols="9">
-          <VCard class="pa-2 my-6">
-            <VCardTitle class="justify-center">File details</VCardTitle>
-            <VCardText>
-              <template v-if="selectedItem">
-                <p>
-                  <span class="mr-2">
-                    Exploring file <strong>{{ selectedItem.filename }}</strong>
-                  </span>
-                  <BaseButtonDownload
-                    small
-                    :href="path"
-                    :filename="selectedItem.filename"
-                  />
-                </p>
-                <component
-                  :is="componentForType"
-                  v-bind="{ fileManager, filename: selectedItem.filename }"
-                  v-if="supportedTypes.has(fileType)"
-                />
-                <UnitFileExplorerViewerUnknown
-                  v-else
-                  v-bind="{ fileManager, filename: selectedItem.filename }"
-                />
+  <VCard class="pa-2 my-6" min-height="500px" height="auto">
+    <VCardTitle class="justify-center"> Explore your files </VCardTitle>
+    <VCardText class="align-center">
+      <VNavigationDrawer
+        expand-on-hover
+        permanent
+        absolute
+        :mini-variant-width="drawerWidth"
+        width="auto"
+      >
+        <VList>
+          <VListItem>
+            <VListItemTitle class="py-2">File hierarchy</VListItemTitle>
+          </VListItem>
+          <VListItem>
+            <VTreeview
+              dense
+              open-on-click
+              activatable
+              return-object
+              transition
+              rounded
+              :items="fileManager.getTreeItems()"
+              @update:active="setSelectedItem"
+            >
+              <template #prepend="{ item }">
+                <VIcon>
+                  {{ item.icon }}
+                </VIcon>
               </template>
-              <template v-else>
-                <p>Select a file to see it in more details here</p>
-              </template>
-            </VCardText>
-          </VCard>
-        </VCol>
-      </VRow>
+            </VTreeview>
+          </VListItem>
+        </VList>
+      </VNavigationDrawer>
+      <div :style="{ 'margin-left': drawerWidth }">
+        <template v-if="selectedItem">
+          <p>
+            <span class="mr-2">
+              Exploring file <strong>{{ selectedItem.filename }}</strong>
+            </span>
+            <BaseButtonDownload
+              small
+              :href="path"
+              :filename="selectedItem.filename"
+            />
+          </p>
+          <component
+            :is="componentForType"
+            v-bind="{ fileManager, filename: selectedItem.filename }"
+            v-if="supportedTypes.has(fileType)"
+          />
+          <UnitFileExplorerViewerUnknown
+            v-else
+            v-bind="{ fileManager, filename: selectedItem.filename }"
+          />
+        </template>
+        <template v-else>
+          <p>Select a file on the left panel to see it in more details here</p>
+        </template>
+      </div>
     </VCardText>
   </VCard>
 </template>
@@ -76,7 +77,9 @@ export default {
   data() {
     return {
       selectedItem: null,
-      supportedTypes: new Set(['json', 'csv', 'pdf', 'img', 'html', 'txt'])
+      supportedTypes: new Set(['json', 'csv', 'pdf', 'img', 'html', 'txt']),
+      drawer: true,
+      drawerWidth: '150px'
     }
   },
   computed: {

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerCsv.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerCsv.vue
@@ -2,7 +2,7 @@
   <div v-if="loading">Loading</div>
   <div v-else-if="error">
     <p>Could not parse file. Showing content instead</p>
-    <div>{{ csvText }}</div>
+    <div class="explorer__content">{{ csvText }}</div>
   </div>
   <UnitFilterableTable v-else :data="csvContent" />
 </template>

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -62,14 +62,3 @@ export default {
   }
 }
 </script>
-
-<style>
-.v-treeview-node__append {
-  max-width: calc(50%);
-}
-.hestia-treeview-json-value {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-</style>

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -2,7 +2,7 @@
   <div v-if="loading">Loading</div>
   <div v-else-if="error">
     <p>Could not parse file. Showing content instead</p>
-    <div>{{ jsonText }}</div>
+    <div class="explorer__content">{{ jsonText }}</div>
   </div>
   <VTreeview v-else dense transition :items="items">
     <template #prepend="{ item }">

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -10,14 +10,14 @@
         {{ item.icon }}
       </VIcon>
     </template>
-    <template #append="{ item }">
-      <div
-        v-if="!isUndef(item.value)"
-        :title="item.value"
-        class="hestia-treeview-json-value"
-      >
-        {{ item.value }}
+    <template #label="{ item, leaf }">
+      <div v-if="leaf" :title="item.value">
+        <span v-if="!isUndef(item.name)">
+          {{ `${item.name}:` }}
+        </span>
+        <span class="font-italic">{{ item.value }}</span>
       </div>
+      <div v-else>{{ item.name }}</div>
     </template>
   </VTreeview>
 </template>

--- a/vuetify.options.js
+++ b/vuetify.options.js
@@ -1,18 +1,21 @@
 import colors from 'vuetify/es5/util/colors'
 import {
   mdiAlert,
+  mdiCheckboxBlankOutline,
   mdiCheckCircle,
+  mdiChevronLeft,
   mdiClose,
+  mdiCloseBox,
   mdiDatabase,
   mdiDatabaseRemove,
   mdiDownload,
-  mdiHome,
   mdiFacebook,
-  mdiTwitter,
-  mdiStepForward,
-  mdiCloseBox,
+  mdiFileSearch,
+  mdiHome,
+  mdiMagnify,
   mdiMinusBox,
-  mdiCheckboxBlankOutline
+  mdiStepForward,
+  mdiTwitter
 } from '@mdi/js'
 
 export default {
@@ -20,18 +23,21 @@ export default {
     iconfont: 'mdiSvg',
     values: {
       mdiAlert,
+      mdiCheckboxBlankOutline,
       mdiCheckCircle,
+      mdiChevronLeft,
       mdiClose,
+      mdiCloseBox,
       mdiDatabase,
       mdiDatabaseRemove,
       mdiDownload,
-      mdiHome,
       mdiFacebook,
-      mdiTwitter,
-      mdiStepForward,
-      mdiCloseBox,
+      mdiFileSearch,
+      mdiHome,
+      mdiMagnify,
       mdiMinusBox,
-      mdiCheckboxBlankOutline
+      mdiStepForward,
+      mdiTwitter
     }
   },
   theme: {


### PR DESCRIPTION
Edit: PR is ready.
## Previously
This is a work-in-progress PR that I think should be passed to @valentinoli or @andreaskundig as I'm not very familiar with UI development.
The main idea is that we would like to make the file explorer easier to navigate, and to save screen space by hiding the file selector when a file is selected.

The current changes are:
- moved the file selector inside a `VNavigationDrawer` component that is contained within the card of the file explorer.
  - the layout is not great yet, and Alex suggested making the "mini" version of the drawer more compact by only showing the name of the current file or something more relevant than the whole tree
- changed the json viewer to display key-value pairs close by, instead of showing the values on the right-hand side

## Now
Changes:
- moved the file selector inside a `VNavigationDrawer` component that is contained within the card of the file explorer
- changed the json viewer to display key-value pairs close by, instead of showing the values on the right-hand side

Addresses:
- (https://github.com/hestiaAI/digipower-data-experiences/issues/74)
- (https://github.com/hestiaAI/digipower-data-experiences/issues/102)