### PR TITLE
feat: individual files export

### DIFF
--- a/components/the-data-experience/TheDataExperienceDefault.vue
+++ b/components/the-data-experience/TheDataExperienceDefault.vue
@@ -49,12 +49,12 @@
       </VRow>
       <VRow v-if="showDataExplorer">
         <VCol>
-          <UnitFileExplorer v-bind="{ fileManager }" />
+          <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
         </VCol>
       </VRow>
       <VRow v-if="$store.state.config.consent">
         <VCol cols="8 mx-auto">
-          <UnitConsentForm v-bind="{ allResults, defaultView }" />
+          <UnitConsentForm v-bind="{ allResults, defaultView, fileManager }" />
         </VCol>
       </VRow>
     </template>

--- a/components/the-data-experience/TheDataExperienceDefault.vue
+++ b/components/the-data-experience/TheDataExperienceDefault.vue
@@ -49,12 +49,22 @@
       </VRow>
       <VRow v-if="showDataExplorer">
         <VCol>
-          <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
+          <UnitFileExplorer
+            v-bind="{ fileManager, selectable: consentForm !== null }"
+          />
         </VCol>
       </VRow>
-      <VRow v-if="$store.state.config.consent">
+      <VRow v-if="consentForm">
         <VCol cols="8 mx-auto">
-          <UnitConsentForm v-bind="{ allResults, defaultView, fileManager }" />
+          <UnitConsentForm
+            v-bind="{
+              consentForm,
+              allResults,
+              defaultView,
+              fileManager,
+              showDataExplorer
+            }"
+          />
         </VCol>
       </VRow>
     </template>
@@ -108,6 +118,16 @@ export default {
     },
     isRdfNeeded() {
       return this.defaultView.filter(v => 'query' in v).length > 0
+    },
+    consentForm() {
+      const consent = this.$store.state.config.consent
+      const key = this.$route.params.key
+      if (key in consent) {
+        return consent[key]
+      } else if ('default' in consent) {
+        return consent.default
+      }
+      return null
     }
   },
   methods: {

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -34,6 +34,7 @@
           :disabled="!zipReady || (sentStatus && !sentError)"
           @click="sendForm"
         />
+        <p v-if="zipReady">ZIP size: {{ humanReadablefileSize }}</p>
         <p v-if="sentError">
           Sending failed. Please download the file and send it by email.
         </p>
@@ -157,6 +158,15 @@ export default {
     },
     key() {
       return this.$route.params.key
+    },
+    humanReadablefileSize() {
+      const bytes = this.encryptedZipFile.length
+      const i = Math.floor(Math.log(bytes) / Math.log(1024))
+      return (
+        (bytes / Math.pow(1024, i)).toFixed(2) * 1 +
+        ' ' +
+        ['B', 'kB', 'MB', 'GB', 'TB'][i]
+      )
     }
   },
   watch: {

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -1,11 +1,11 @@
 <template>
-  <VForm v-if="consent">
+  <VForm>
     <VCard class="pa-2 my-6">
       <VCardText>
         <UnitConsentFormSection
           v-for="(section, index) in consent"
           :key="`section-${index}`"
-          v-bind="{ section, index, dataCheckboxDisabled }"
+          v-bind="{ section, index, dataCheckboxDisabled, showDataExplorer }"
           @change="updateConsent"
         />
         <BaseButton
@@ -66,6 +66,10 @@ const VERSION = 2
 
 export default {
   props: {
+    consentForm: {
+      type: Array,
+      required: true
+    },
     allResults: {
       type: Array,
       required: true
@@ -77,11 +81,15 @@ export default {
     fileManager: {
       type: FileManager,
       required: true
+    },
+    showDataExplorer: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
     return {
-      consent: null,
+      consent: JSON.parse(JSON.stringify(this.consentForm)),
       includedResults: [],
       zipFile: [],
       encryptedZipFile: [],
@@ -99,9 +107,6 @@ export default {
       return this.generateStatus && !this.generateError
     },
     missingRequired() {
-      if (!this.consent) {
-        return false
-      }
       // If one section with attribute required has not been filled
       return !this.consent.every(section => {
         if ('required' in section) {
@@ -167,16 +172,6 @@ export default {
   },
   methods: {
     init() {
-      // Get the relevant consent form
-      const consent = this.$store.state.config.consent
-      if (this.key in consent) {
-        this.consent = JSON.parse(JSON.stringify(consent[this.key]))
-      } else if ('default' in consent) {
-        this.consent = JSON.parse(JSON.stringify(consent.default))
-      }
-      if (!this.consent) {
-        return
-      }
       // Add titles and keys to the data section
       const section = this.consent.find(section => section.type === 'data')
       section.titles = this.defaultView.map(e => e.title)

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -224,7 +224,7 @@ export default {
         for (const file of files) {
           zipFilesFolder.file(
             file.filename,
-            await this.fileManager.getText(file.filename)
+            this.fileManager.fileDict[file.filename]
           )
         }
       }

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -149,6 +149,9 @@ export default {
     },
     dataCheckboxDisabled() {
       return this.allResults.map(r => typeof r === 'undefined')
+    },
+    key() {
+      return this.$route.params.key
     }
   },
   watch: {
@@ -164,11 +167,10 @@ export default {
   },
   methods: {
     init() {
-      const key = this.$route.params.key
       // Get the relevant consent form
       const consent = this.$store.state.config.consent
-      if (key in consent) {
-        this.consent = JSON.parse(JSON.stringify(consent[key]))
+      if (this.key in consent) {
+        this.consent = JSON.parse(JSON.stringify(consent[this.key]))
       } else if ('default' in consent) {
         this.consent = JSON.parse(JSON.stringify(consent.default))
       }
@@ -223,7 +225,7 @@ export default {
       // Add whole files
       if (this.includedResults.includes('file-explorer')) {
         const zipFilesFolder = zip.folder('files')
-        const files = this.$store.state.selectedFiles
+        const files = this.$store.state.selectedFiles[this.key] ?? []
         for (const file of files) {
           zipFilesFolder.file(
             file.filename,

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -56,6 +56,7 @@
 
 <script>
 import JSZip from 'jszip'
+import FileManager from '~/utils/file-manager.js'
 
 const _sodium = require('libsodium-wrappers')
 
@@ -71,6 +72,10 @@ export default {
     },
     defaultView: {
       type: Array,
+      required: true
+    },
+    fileManager: {
+      type: FileManager,
       required: true
     }
   },
@@ -214,6 +219,18 @@ export default {
             JSON.stringify(content)
           )
         })
+
+      // Add whole files
+      if (this.includedResults.includes('file-explorer')) {
+        const zipFilesFolder = zip.folder('files')
+        const files = this.$store.state.selectedFiles
+        for (const file of files) {
+          zipFilesFolder.file(
+            file.filename,
+            await this.fileManager.getText(file.filename)
+          )
+        }
+      }
 
       const content = await zip.generateAsync({ type: 'uint8array' })
       this.zipFile = content

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -24,6 +24,14 @@
         @change="updateConsent"
       ></VCheckbox>
       <VCheckbox
+        v-model="includedResults"
+        :readonly="readonly"
+        dense
+        label="Selected files in file explorer"
+        value="file-explorer"
+        @change="updateConsent"
+      ></VCheckbox>
+      <VCheckbox
         v-for="(title, j) in section.additional"
         :key="`data-additional-${j}`"
         v-model="includedResults"

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -24,6 +24,7 @@
         @change="updateConsent"
       ></VCheckbox>
       <VCheckbox
+        v-if="showDataExplorer"
         v-model="includedResults"
         :readonly="readonly"
         dense
@@ -113,6 +114,10 @@ export default {
     dataCheckboxDisabled: {
       type: Array,
       default: () => []
+    },
+    showDataExplorer: {
+      type: Boolean,
+      default: true
     }
   },
   data() {

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -8,12 +8,14 @@
             <VCardTitle class="justify-center">File hierarchy</VCardTitle>
             <VCardText>
               <VTreeview
+                v-model="selectedFiles"
                 dense
                 open-on-click
                 activatable
                 rounded
                 return-object
                 transition
+                :selectable="selectable"
                 :items="fileManager.getTreeItems()"
                 @update:active="setSelectedItem"
               >
@@ -71,6 +73,10 @@ export default {
     fileManager: {
       type: FileManager,
       required: true
+    },
+    selectable: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -101,6 +107,14 @@ export default {
         import(
           `~/components/unit/file-explorer/viewer/UnitFileExplorerViewer${postfix}`
         )
+    },
+    selectedFiles: {
+      get() {
+        return this.$store.state.selectedFiles
+      },
+      set(value) {
+        this.$store.commit('setSelectedFiles', value)
+      }
     }
   },
   methods: {

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -108,12 +108,15 @@ export default {
           `~/components/unit/file-explorer/viewer/UnitFileExplorerViewer${postfix}`
         )
     },
+    key() {
+      return this.$route.params.key
+    },
     selectedFiles: {
       get() {
-        return this.$store.state.selectedFiles
+        return this.$store.state.selectedFiles[this.key]
       },
       set(value) {
-        this.$store.commit('setSelectedFiles', value)
+        this.$store.commit('setSelectedFiles', { key: this.key, value })
       }
     }
   },

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -107,6 +107,13 @@
           </VCol>
         </VRow>
       </VCard>
+
+      <!-- File explorer -->
+      <VRow v-if="hasFileExplorer">
+        <VCol>
+          <UnitFileExplorer v-bind="{ fileManager, selectable: false }" />
+        </VCol>
+      </VRow>
     </template>
   </div>
 </template>
@@ -114,6 +121,7 @@
 <script>
 import JSZip from 'jszip'
 import FileSaver from 'file-saver'
+import FileManager from '~/utils/file-manager'
 
 const _sodium = require('libsodium-wrappers')
 
@@ -130,7 +138,8 @@ export default {
       message: '',
       experience: null,
       results: null,
-      consent: null
+      consent: null,
+      fileManager: null
     }
   },
   computed: {
@@ -154,6 +163,9 @@ export default {
     },
     sortedResults() {
       return this.results.slice(0).sort((a, b) => a.index - b.index)
+    },
+    hasFileExplorer() {
+      return this.fileManager?.fileList.length > 0
     }
   },
   methods: {
@@ -220,15 +232,28 @@ export default {
       }
       // Extract files
       try {
+        // Experience details
         this.experience = JSON.parse(
           await zip.file('experience.json').async('string')
         )
+        // Consent log
         this.consent = JSON.parse(
           await zip.file('consent.json').async('string')
         )
-        const files = zip.file(/block[0-9]+.json/)
-        const res = await Promise.all(files.map(r => r.async('string')))
-        this.results = res.map(JSON.parse)
+        // Included results
+        const resultFiles = zip.file(/block[0-9]+.json/)
+        const results = await Promise.all(
+          resultFiles.map(r => r.async('string'))
+        )
+        this.results = results.map(JSON.parse)
+        // Included whole files
+        const folderContent = zip.file(/files\/.*/)
+        const blobs = await Promise.all(folderContent.map(r => r.async('blob')))
+        const files = folderContent.map(
+          (r, i) => new File([blobs[i]], r.name.substr(6))
+        )
+        this.fileManager = new FileManager(this.manifest.preprocessors)
+        await this.fileManager.init(files, true)
       } catch (error) {
         this.handleError(
           error,

--- a/store/index.js
+++ b/store/index.js
@@ -6,7 +6,8 @@ export const state = () => ({
     ...config
   },
   manifestMap,
-  power: false
+  power: false,
+  selectedFiles: []
 })
 
 export const getters = {
@@ -48,5 +49,8 @@ export const getters = {
 export const mutations = {
   updatePower(state, power) {
     state.power = power
+  },
+  setSelectedFiles(state, selectedFiles) {
+    state.selectedFiles = selectedFiles
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -7,7 +7,7 @@ export const state = () => ({
   },
   manifestMap,
   power: false,
-  selectedFiles: []
+  selectedFiles: {}
 })
 
 export const getters = {
@@ -50,7 +50,7 @@ export const mutations = {
   updatePower(state, power) {
     state.power = power
   },
-  setSelectedFiles(state, selectedFiles) {
-    state.selectedFiles = selectedFiles
+  setSelectedFiles(state, { key, value }) {
+    state.selectedFiles[key] = value
   }
 }


### PR DESCRIPTION
Changes:
- Add checkboxes next to each file in the file explorer (but only if a consent form is defined for this experience)
- Add checkbox in consent form to include selected files in the export
- Import page recreates a file explorer with the included files
- Consent form shows the size of the zip before sending it

I'm using Vuex to store the names of the selected files, it's cleaner than using props since we are passing data to sibling components (UnitFileExplorer and UnitConsentForm).

Directly related issues:
- https://github.com/hestiaAI/digipower-data-experiences/issues/91
- https://github.com/hestiaAI/digipower-data-experiences/issues/88

Indirectly related issue:
- https://github.com/hestiaAI/hestialabs-experiences/issues/265