### PR TITLE
fix: attempt at renaming blob

### DIFF
--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -56,6 +56,7 @@
 <script>
 import JSZip from 'jszip'
 import FileManager from '~/utils/file-manager.js'
+import { padNumber } from '~/utils/utils'
 
 const _sodium = require('libsodium-wrappers')
 
@@ -219,10 +220,7 @@ export default {
           const content = JSON.parse(JSON.stringify(this.defaultView[i]))
           content.result = JSON.parse(this.allResults[i])
           content.index = i
-          zip.file(
-            `block${i.toString().padStart(2, '0')}.json`,
-            JSON.stringify(content)
-          )
+          zip.file(`block${padNumber(i, 2)}.json`, JSON.stringify(content))
         })
 
       // Add whole files
@@ -261,13 +259,20 @@ export default {
       // Programmatically create the form data
       // Names must correspond to the dummy form defined in /static/export-data-form-dummy.html
       const formData = new FormData()
+      const date = new Date(this.timestamp)
+      const yearMonthDay = `${date.getUTCFullYear()}-${padNumber(
+        date.getUTCMonth(),
+        2
+      )}-${padNumber(date.getUTCDate(), 2)}`
+      const filename = `${this.key}_${yearMonthDay}_${padNumber(
+        date.getUTCHours(),
+        2
+      )}:${padNumber(date.getUTCMinutes(), 2)}.zip`
       formData.append('form-name', 'export-data')
-      const zipBlob = new Blob(
-        [this.encryptedZipFile],
-        { type: 'application/zip' },
-        `exported-data-${this.timestamp}.zip`
-      )
-      formData.append('encrypted-zip', zipBlob)
+      const zip = new File([this.encryptedZipFile], filename, {
+        type: 'application/zip'
+      })
+      formData.append('encrypted-zip', zip, filename)
       fetch('/', {
         method: 'POST',
         body: formData

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -73,3 +73,8 @@ export function rdfToQuads(rdf, format = 'N3') {
   const quads = parser.parse(rdf)
   return quads
 }
+
+/* Transform integer x to a string of length n, left-padded with zeros. */
+export function padNumber(x, n) {
+  return x.toString().padStart(n, '0')
+}


### PR DESCRIPTION
It may not work, but we are forced to deploy it on the test instance to see if it does. Now the filename would include the experience name and human-readable date

Related:
- https://github.com/hestiaAI/digipower-data-experiences/issues/105
- https://github.com/hestiaAI/digipower-data-experiences/issues/35