### PR TITLE
style: improved file explorer summary string and left panel

### DIFF
--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -6,7 +6,7 @@
       :mini-variant-width="miniWidth"
       absolute
       permanent
-      width="100%"
+      width="80%"
     >
       <template #prepend>
         <VListItem class="px-2">
@@ -23,6 +23,20 @@
         <VListItem v-if="selectable && !mini">
           Size of selected files: {{ selectionSizeString }}
         </VListItem>
+        <VListItem v-if="!mini">
+          <VTextField
+            v-model="search"
+            label="Search for files"
+            placeholder="Enter part of a file name..."
+            clearable
+            hide-details
+            prepend-icon="$vuetify.icons.mdiMagnify"
+            class="my-4 pr-3"
+            style="max-width: 500px"
+            outlined
+            dense
+          />
+        </VListItem>
       </template>
 
       <div :style="drawerMiniFileLabelStyle" class="drawer-mini-file-label">
@@ -30,18 +44,6 @@
       </div>
 
       <div :class="miniWidthPaddingLeftClass">
-        <VTextField
-          v-model="search"
-          label="Search files"
-          placeholder="Type..."
-          clearable
-          hide-details
-          prepend-icon="$vuetify.icons.mdiMagnify"
-          class="my-4 pr-3"
-          style="max-width: 500px"
-          outlined
-          dense
-        />
         <VTreeview
           v-model="selectedFiles"
           dense
@@ -66,20 +68,21 @@
     <VCardTitle class="justify-center">Explore your files</VCardTitle>
     <div :class="miniWidthPaddingLeftClass">
       <VCardText>
-        Analysed <b>{{ nFiles }}</b> {{ plurify('file', nFiles) }} (
-        <b>{{ dataSizeString }} </b>)
+        Analysed <b>{{ nFiles }}</b> {{ plurify('file', nFiles) }} (<b>{{
+          dataSizeString
+        }}</b
+        >)
         <template v-if="nDataPoints">
-          and found <b>{{ nDataPoints.toLocaleString() }}</b> data points
+          and found <b>{{ nDataPoints.toLocaleString() }}</b> datapoints
         </template>
         :
-        <VList v-if="sortedExtensionTexts" :dense="true">
-          <VListItem v-for="(text, i) in sortedExtensionTexts" :key="i">
-            <VListItemIcon>
-              <VIcon>$vuetify.icons.mdiMinus</VIcon>
-            </VListItemIcon>
-            <VListItemContent>{{ text }}</VListItemContent>
-          </VListItem>
-        </VList>
+        <ul v-if="sortedExtensionTexts">
+          <li
+            v-for="(text, i) in sortedExtensionTexts"
+            :key="i"
+            v-html="text"
+          />
+        </ul>
       </VCardText>
       <VCardText>
         <template v-if="filename">
@@ -244,6 +247,8 @@ export default {
         if (!containers.has(item?.type)) {
           this.selectedItem = item
         }
+      } else {
+        this.selectedItem = {}
       }
     },
     async setNumberOfDataPoints() {
@@ -273,24 +278,28 @@ export default {
         const topFilesDescription = shownFiles
           .map(
             ([f, nPoints]) =>
-              `${f} ${
+              `<em>${f}</em>${
                 nPoints === 0
                   ? ''
-                  : `(${nPoints.toLocaleString()} data ${plurify(
-                      'point',
+                  : ` (${nPoints.toLocaleString()} ${plurify(
+                      ext === 'txt' ? 'line' : 'datapoint',
                       nPoints
                     )})`
               }`
           )
           .join(', ')
-        return ` ${c} ${ext === 'other' ? '' : '.'}${ext}${
-          nPointsExt > 0 ? ` (${nPointsExt.toLocaleString()} data points)` : ''
+        return `<b>${c} ${plurify(
+          ext === 'other' ? 'other format' : ext.toUpperCase(),
+          c
+        )}</b>${
+          nPointsExt > 0
+            ? ` (${nPointsExt.toLocaleString()} ${plurify(
+                ext === 'txt' ? 'line' : 'datapoint',
+                nPointsExt
+              )})`
+            : ':'
         }${
-          files.length > showAtMost
-            ? ' including: '
-            : ext !== 'other'
-            ? ':'
-            : ` ${plurify('format', c)}`
+          files.length > showAtMost ? ' including: ' : ''
         } ${topFilesDescription}`
       })
     }


### PR DESCRIPTION
Addressing most of the comments in:
- (https://github.com/hestiaAI/digipower-data-experiences/issues/71)
- (https://github.com/hestiaAI/digipower-data-experiences/issues/74)

![image](https://user-images.githubusercontent.com/16099301/145209807-835867de-5e39-4f7b-959a-9f1042c89c59.png)

Changes:
- summary of files:
  - bold font to file type and number of occurrences
  - capitalized extensions
  - italicized file names
  - changed list format (more compact and simple)
  - `data points -> lines` for text files
  - `data points -> datapoints` elsewhere
  - summary doesn't disappear when a file is selected
- left panel:
  - search box always appears at the top
  - `100% -> 80%` width 
  - clicking on selected file unselects it

Some problems that remain (but that could be solved in a following PR):
- summary of files:
  - path of files could be shortened, but we cannot keep just the file name since we'll have duplicates (e.g. google my activity)
- left panel:
  - need to improve experience of going from it back to the main panel