### PR TITLE
feat: select files in consent form

### DIFF
--- a/components/TheAppBar.vue
+++ b/components/TheAppBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <VAppBar fixed app color="white" height="75" style="z-index: 2000">
+    <VAppBar fixed app color="white" height="75">
       <VAppBarNavIcon
         aria-label="Open navigation menu"
         @click.stop="drawer = !drawer"

--- a/components/the-data-experience/TheDataExperienceDefault.vue
+++ b/components/the-data-experience/TheDataExperienceDefault.vue
@@ -28,9 +28,7 @@
     <template v-if="success">
       <VRow v-if="showDataExplorer">
         <VCol>
-          <UnitFileExplorer
-            v-bind="{ fileManager, selectable: consentForm !== null }"
-          />
+          <UnitFileExplorer v-bind="{ fileManager, selectable: false }" />
         </VCol>
       </VRow>
       <VRow v-for="(defaultViewElements, index) in defaultView" :key="index">

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -5,7 +5,13 @@
         <UnitConsentFormSection
           v-for="(section, index) in consent"
           :key="`section-${index}`"
-          v-bind="{ section, index, dataCheckboxDisabled, showDataExplorer }"
+          v-bind="{
+            section,
+            index,
+            dataCheckboxDisabled,
+            showDataExplorer,
+            fileManager
+          }"
           @change="updateConsent"
         />
         <BaseButton
@@ -125,7 +131,10 @@ export default {
             typeof section.required === 'boolean'
           ) {
             // Some data must be given
-            return section.includedResults.length > 0
+            return (
+              section.includedResults.length > 0 ||
+              this.$store.state.selectedFiles[this.key].length > 0
+            )
           }
         }
         return true
@@ -219,15 +228,13 @@ export default {
         })
 
       // Add whole files
-      if (this.includedResults.includes('file-explorer')) {
-        const zipFilesFolder = zip.folder('files')
-        const files = this.$store.state.selectedFiles[this.key] ?? []
-        for (const file of files) {
-          zipFilesFolder.file(
-            file.filename,
-            this.fileManager.fileDict[file.filename]
-          )
-        }
+      const zipFilesFolder = zip.folder('files')
+      const files = this.$store.state.selectedFiles[this.key]
+      for (const file of files) {
+        zipFilesFolder.file(
+          file.filename,
+          this.fileManager.fileDict[file.filename]
+        )
       }
 
       const content = await zip.generateAsync({ type: 'uint8array' })

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -23,15 +23,40 @@
         :value="section.keys[j]"
         @change="updateConsent"
       ></VCheckbox>
-      <VCheckbox
-        v-if="showDataExplorer"
-        v-model="includedResults"
-        :readonly="readonly"
-        dense
-        label="Selected files in file explorer"
-        value="file-explorer"
-        @change="updateConsent"
-      ></VCheckbox>
+
+      <p v-if="readonly" class="mb-4">
+        Individual files (<b>{{ selectedFiles.length }}</b> selected)
+      </p>
+      <VDialog v-else v-model="dialog" width="80%">
+        <template #activator="{ on }">
+          <div>
+            <span class="mr-2"
+              >Individual files (<b>{{ selectedFiles.length }}</b>
+              selected):</span
+            >
+            <BaseButton class="mb-4" text="Select files" v-on="on" />
+          </div>
+        </template>
+
+        <VDivider></VDivider>
+
+        <VCard>
+          <VCardTitle class="text-h5 grey lighten-2"> Select files </VCardTitle>
+
+          <UnitFileExplorer
+            v-bind="{ fileManager, selectable: true }"
+            style="height: 300px"
+          />
+
+          <VDivider></VDivider>
+
+          <VCardActions>
+            <VSpacer></VSpacer>
+            <VBtn color="primary" text @click="dialog = false"> Save </VBtn>
+          </VCardActions>
+        </VCard>
+      </VDialog>
+
       <VCheckbox
         v-for="(title, j) in section.additional"
         :key="`data-additional-${j}`"
@@ -97,6 +122,8 @@
 </template>
 
 <script>
+import FileManager from '~/utils/file-manager.js'
+
 export default {
   props: {
     section: {
@@ -118,13 +145,29 @@ export default {
     showDataExplorer: {
       type: Boolean,
       default: true
+    },
+    fileManager: {
+      type: FileManager,
+      required: true
     }
   },
   data() {
     return {
       selected: null,
       value: null,
-      includedResults: null
+      includedResults: null,
+      dialog: false
+    }
+  },
+  computed: {
+    key() {
+      return this.$route.params.key
+    },
+    selectedFiles() {
+      if (this.readonly) {
+        return Object.keys(this.fileManager.fileDict)
+      }
+      return this.$store.state.selectedFiles[this.key]
     }
   },
   created() {

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -49,7 +49,7 @@
 
           <VCardActions>
             <VSpacer></VSpacer>
-            <VBtn color="primary" text @click="dialog = false"> Save </VBtn>
+            <VBtn color="primary" text @click="dialog = false"> Close </VBtn>
           </VCardActions>
         </VCard>
       </VDialog>

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -49,7 +49,7 @@
 
           <VCardActions>
             <VSpacer></VSpacer>
-            <VBtn color="primary" text @click="dialog = false"> Close </VBtn>
+            <VBtn color="primary" text @click="dialog = false"> OK </VBtn>
           </VCardActions>
         </VCard>
       </VDialog>

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -43,10 +43,7 @@
         <VCard>
           <VCardTitle class="text-h5 grey lighten-2"> Select files </VCardTitle>
 
-          <UnitFileExplorer
-            v-bind="{ fileManager, selectable: true }"
-            style="height: 300px"
-          />
+          <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
 
           <VDivider></VDivider>
 

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -13,6 +13,7 @@
         --cursor-style: wait !important;
       }
     </style>
+    <!-- https://github.com/vuetifyjs/vuetify/issues/5617 -->
     <VNavigationDrawer
       ref="drawer"
       :mini-variant.sync="mini"
@@ -20,6 +21,10 @@
       absolute
       permanent
       width="100%"
+      style="
+        transform: translateX(0) !important;
+        visibility: visible !important;
+      "
     >
       <template #prepend>
         <VListItem class="px-2">

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -67,7 +67,7 @@
           <UnitConsentFormSection
             v-for="(section, index) in consent"
             :key="`section-${index}`"
-            v-bind="{ section, index, readonly: true }"
+            v-bind="{ section, index, readonly: true, fileManager }"
           />
         </VCardText>
       </VCard>

--- a/store/index.js
+++ b/store/index.js
@@ -7,7 +7,7 @@ export const state = () => ({
   },
   manifestMap,
   power: false,
-  selectedFiles: {}
+  selectedFiles: Object.fromEntries(Object.keys(manifestMap).map(k => [k, []]))
 })
 
 export const getters = {


### PR DESCRIPTION
Instead of having checkboxes in the file-explorer experience, we can open a dialog from the consent form. This dialog contains a file-explorer with checkboxes.

https://github.com/hestiaAI/digipower-data-experiences/issues/111

![Screenshot_20211210_180658](https://user-images.githubusercontent.com/25420002/145613965-df4b1506-d135-4a30-acd8-4b2cdf718c67.png)

![Screenshot_20211210_180840](https://user-images.githubusercontent.com/25420002/145613980-127a017b-8873-48ad-8395-e5f45dc77d47.png)

TODO:
- When we open a file that takes a lot of vertical space (e.g. an unwrapped json or an image) and open the navigation drawer, then the component does not shrink, it just shows blank space where the file was shown. (This was already the case before this PR)