### PR TITLE
refactor: change custom pipeline arguments

### DIFF
--- a/components/unit/UnitCustomPipeline.vue
+++ b/components/unit/UnitCustomPipeline.vue
@@ -61,12 +61,12 @@ export default {
       this.progress = true
       setTimeout(async () => {
         try {
-          const result = await this.customPipeline(
-            this.fileManager,
-            this.$store.getters.manifest(this.$route),
-            this.parameter,
-            this.defaultViewElements.customPipelineOptions
-          )
+          const result = await this.customPipeline({
+            fileManager: this.fileManager,
+            manifest: this.$store.getters.manifest(this.$route),
+            parameter: this.parameter,
+            options: this.defaultViewElements.customPipelineOptions
+          })
           this.$emit('update', result)
         } catch (error) {
           console.error(error)

--- a/manifests/experiences/netflix/pipeline.js
+++ b/manifests/experiences/netflix/pipeline.js
@@ -1,12 +1,12 @@
 import { genericDateViewer } from '~/manifests/generic-pipelines'
 
-async function viewingData(fileManager) {
+async function viewingData({ fileManager }) {
   return await fileManager.getCsvItems(
     'CONTENT_INTERACTION/ViewingActivity.csv'
   )
 }
 
-async function messagesData(fileManager) {
+async function messagesData({ fileManager }) {
   const result = await fileManager.getCsvItems(
     'MESSAGES/MessagesSentByNetflix.csv'
   )

--- a/manifests/experiences/tracker-control/pipeline.js
+++ b/manifests/experiences/tracker-control/pipeline.js
@@ -1,4 +1,4 @@
-async function trackerControl(fileManager) {
+async function trackerControl({ fileManager }) {
   return await fileManager.getCsvItems('input.csv')
 }
 

--- a/manifests/experiences/twitter/pipeline.js
+++ b/manifests/experiences/twitter/pipeline.js
@@ -25,7 +25,7 @@ function dashboardFillItems(items, impressionAttributes, isEngagement) {
   })
 }
 
-async function dashboard(fileManager) {
+async function dashboard({ fileManager }) {
   const engagementsFile = JSON.parse(
     await fileManager.getPreprocessedText('data/ad-engagements.js')
   )
@@ -55,7 +55,7 @@ async function dashboard(fileManager) {
   return { headers, items }
 }
 
-async function advertisersPerDay(fileManager) {
+async function advertisersPerDay({ fileManager }) {
   // JSON iterator
   const impressionsFile = JSON.parse(
     await fileManager.getPreprocessedText('data/ad-impressions.js')
@@ -80,7 +80,7 @@ async function advertisersPerDay(fileManager) {
   return { headers, items }
 }
 
-async function targetingTree(fileManager) {
+async function targetingTree({ fileManager }) {
   // JSON iterator on impressions
   const impressionsFile = JSON.parse(
     await fileManager.getPreprocessedText('data/ad-impressions.js')
@@ -130,7 +130,7 @@ async function targetingTree(fileManager) {
   return { headers, items }
 }
 
-async function targetingTypesAndValues(fileManager) {
+async function targetingTypesAndValues({ fileManager }) {
   // JSON iterator on impressions
   const impressionsFile = JSON.parse(
     await fileManager.getPreprocessedText('data/ad-impressions.js')
@@ -164,7 +164,7 @@ async function targetingTypesAndValues(fileManager) {
   return { headers, items }
 }
 
-async function allAdvertisers(fileManager) {
+async function allAdvertisers({ fileManager }) {
   // JSON iterator on impressions
   const impressionsFile = JSON.parse(
     await fileManager.getPreprocessedText('data/ad-impressions.js')
@@ -183,7 +183,7 @@ async function allAdvertisers(fileManager) {
   return { headers, items }
 }
 
-async function selectTargetingTree(fileManager, _, parameter) {
+async function selectTargetingTree({ fileManager, parameter }) {
   // JSON iterator on impressions
   const impressionsFile = JSON.parse(
     await fileManager.getPreprocessedText('data/ad-impressions.js')

--- a/manifests/experiences/uber/pipeline.js
+++ b/manifests/experiences/uber/pipeline.js
@@ -4,15 +4,15 @@ import {
   genericLocationViewer
 } from '~/manifests/generic-pipelines'
 
-async function tripsData(fileManager) {
+async function tripsData({ fileManager }) {
   return await fileManager.getCsvItems('Uber Data/Rider/trips_data.csv')
 }
 
-async function tripsRawData(fileManager) {
+async function tripsRawData({ fileManager }) {
   return await fileManager.getText('Uber Data/Rider/trips_data.csv')
 }
 
-async function tripsGraphData(fileManager) {
+async function tripsGraphData({ fileManager }) {
   const tripsData = await fileManager.getCsvItems(
     'Uber Data/Rider/trips_data.csv'
   )
@@ -35,8 +35,8 @@ async function tripsGraphData(fileManager) {
   return { headers: ['source', 'target', 'value'], items: filteredValues }
 }
 
-async function tripsKeplerData(fileManager) {
-  return { rawCsv: await tripsRawData(fileManager), config: keplerConfig }
+async function tripsKeplerData({ fileManager }) {
+  return { rawCsv: await tripsRawData({ fileManager }), config: keplerConfig }
 }
 
 export default {

--- a/manifests/generic-pipelines.js
+++ b/manifests/generic-pipelines.js
@@ -134,7 +134,7 @@ function extractCsvEntries({ items }) {
   })
 }
 
-async function genericDateViewer(fileManager) {
+async function genericDateViewer({ fileManager }) {
   const filenames = fileManager.getFilenames()
 
   const csvFilenames = filenames.filter(name => name.endsWith('.csv'))
@@ -164,7 +164,7 @@ async function genericDateViewer(fileManager) {
   return { headers, items }
 }
 
-async function timedObservationViewer(fileManager, manifest) {
+async function timedObservationViewer({ fileManager, manifest }) {
   const params = manifest.timedObservationsViewer
   const matchingFilenames = fileManager
     .getFilenames()
@@ -293,7 +293,7 @@ function extractCsvLocations({ items }) {
   })
 }
 
-async function genericLocationViewer(fileManager) {
+async function genericLocationViewer({ fileManager }) {
   const filenames = fileManager.getFilenames()
 
   const csvFilenames = filenames.filter(name => name.endsWith('.csv'))


### PR DESCRIPTION
Custom pipelines need various arguments, but most of the time not all of them. This PR allows a custom pipeline function to get the parameters it needs without caring about the order. It should be a bit less error-prone, especially if we add/remove some arguments in the future