### PR TITLE
style: update file selection in consent form

### DIFF
--- a/components/unit/consent-form/SelectFilesDialog.vue
+++ b/components/unit/consent-form/SelectFilesDialog.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <VDialog v-model="dialog" width="80%" persistent scrollable>
+      <template #activator="{ on }">
+        <BaseButton class="mb-4" text="Select files" v-on="on" />
+      </template>
+
+      <VDivider></VDivider>
+
+      <VCard>
+        <VCardTitle class="text-h5 grey lighten-2"> Select files </VCardTitle>
+
+        <VCardText style="height: 500px">
+          <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
+        </VCardText>
+
+        <VDivider></VDivider>
+
+        <VCardActions>
+          <VSpacer></VSpacer>
+          <VBtn color="primary" text @click="clear"> Clear selection </VBtn>
+          <VBtn color="primary" text @click="ok"> OK </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+  </div>
+</template>
+
+<script>
+import FileManager from '~/utils/file-manager.js'
+
+export default {
+  props: {
+    fileManager: {
+      type: FileManager,
+      required: true
+    }
+  },
+  data() {
+    return {
+      dialog: false
+    }
+  },
+  computed: {
+    key() {
+      return this.$route.params.key
+    }
+  },
+  methods: {
+    ok() {
+      this.dialog = false
+      this.$emit('return', { clear: false })
+    },
+    clear() {
+      this.$store.commit('setSelectedFiles', { key: this.key, value: [] })
+      this.dialog = false
+      this.$emit('return', { clear: true })
+    }
+  }
+}
+</script>

--- a/components/unit/consent-form/SelectFilesDialog.vue
+++ b/components/unit/consent-form/SelectFilesDialog.vue
@@ -2,7 +2,12 @@
   <div>
     <VDialog v-model="dialog" width="80%" persistent scrollable>
       <template #activator="{ on }">
-        <BaseButton class="mb-4" text="Select files" v-on="on" />
+        <BaseButton
+          :ref="buttonRef"
+          class="mb-4"
+          text="Select files"
+          v-on="on"
+        />
       </template>
 
       <VDivider></VDivider>
@@ -34,6 +39,10 @@ export default {
     fileManager: {
       type: FileManager,
       required: true
+    },
+    buttonRef: {
+      type: String,
+      default: 'selectFilesDialogButton'
     }
   },
   data() {

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -124,10 +124,13 @@ export default {
             typeof section.required === 'boolean'
           ) {
             // Some data must be given
-            return (
-              section.includedResults.length > 0 ||
-              this.$store.state.selectedFiles[this.key].length > 0
-            )
+            if (
+              section.includedResults.length === 1 &&
+              section.includedResults[0] === 'file-explorer'
+            ) {
+              return this.$store.state.selectedFiles[this.key].length > 0
+            }
+            return section.includedResults.length > 0
           }
         }
         return true

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -14,13 +14,6 @@
           }"
           @change="updateConsent"
         />
-        <p>
-          Please download the ZIP file containing the results and
-          <a v-if="config.filedrop" :href="config.filedrop" target="_blank"
-            >drop it here</a
-          >
-          <template v-else>send it by email</template>.
-        </p>
         <p v-if="missingRequired" style="color: red">
           Some required fields are not filled in.
         </p>
@@ -32,26 +25,42 @@
           Some data required for sending this form has not been included:
           {{ missingRequiredData.join(', ') }}.
         </p>
-        <BaseButton
-          text="Download results"
-          :status="generateStatus"
-          :error="generateError"
-          :progress="generateProgress"
-          :disabled="
-            missingRequired ||
-            missingRequiredDataProcessing.length > 0 ||
-            missingRequiredData.length > 0
-          "
-          @click="generateZIP"
-        />
-        <BaseButtonDownloadData
-          v-show="false"
-          ref="downloadBtn"
-          :data="zipFile"
-          :filename="filename"
-          extension="zip"
-          text="Download"
-        />
+        <VRow>
+          <VCol>
+            <VIcon v-if="config.filedrop" class="mr-2" color="#424242"
+              >$vuetify.icons.mdiNumeric1CircleOutline</VIcon
+            >
+            <BaseButton
+              text="Download results"
+              :status="generateStatus"
+              :error="generateError"
+              :progress="generateProgress"
+              :disabled="
+                missingRequired ||
+                missingRequiredDataProcessing.length > 0 ||
+                missingRequiredData.length > 0
+              "
+              @click="generateZIP"
+            />
+            <BaseButtonDownloadData
+              v-show="false"
+              ref="downloadBtn"
+              :data="zipFile"
+              :filename="filename"
+              extension="zip"
+              text="Download"
+            />
+          </VCol>
+          <VCol v-if="config.filedrop">
+            <VIcon class="mr-2" color="#424242"
+              >$vuetify.icons.mdiNumeric2CircleOutline</VIcon
+            >
+            <a :href="config.filedrop" target="_blank">
+              <BaseButton text="Drop file here" />
+            </a>
+          </VCol>
+        </VRow>
+        <VRow> </VRow>
       </VCardText>
     </VCard>
   </VForm>

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -238,13 +238,15 @@ export default {
         })
 
       // Add whole files
-      const zipFilesFolder = zip.folder('files')
-      const files = this.$store.state.selectedFiles[this.key]
-      for (const file of files) {
-        zipFilesFolder.file(
-          file.filename,
-          this.fileManager.fileDict[file.filename]
-        )
+      if (this.includedResults.includes('file-explorer')) {
+        const zipFilesFolder = zip.folder('files')
+        const files = this.$store.state.selectedFiles[this.key]
+        for (const file of files) {
+          zipFilesFolder.file(
+            file.filename,
+            this.fileManager.fileDict[file.filename]
+          )
+        }
       }
 
       const content = await zip.generateAsync({ type: 'uint8array' })

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -24,35 +24,23 @@
         @change="updateConsent"
       ></VCheckbox>
 
-      <p v-if="readonly" class="mb-4">
-        Individual files (<b>{{ selectedFiles.length }}</b> selected)
-      </p>
-      <VDialog v-else v-model="dialog" width="80%">
-        <template #activator="{ on }">
-          <div>
-            <span class="mr-2"
-              >Individual files (<b>{{ selectedFiles.length }}</b>
-              selected):</span
-            >
-            <BaseButton class="mb-4" text="Select files" v-on="on" />
-          </div>
+      <VCheckbox
+        v-model="includedResults"
+        :readonly="readonly"
+        dense
+        value="file-explorer"
+        @change="updateConsent"
+      >
+        <template #label>
+          <span class="mr-2"
+            >Individual files (<b>{{ selectedFiles.length }}</b> selected)</span
+          >
+          <SelectFilesDialog
+            :file-manager="fileManager"
+            @return="returnDialog"
+          />
         </template>
-
-        <VDivider></VDivider>
-
-        <VCard>
-          <VCardTitle class="text-h5 grey lighten-2"> Select files </VCardTitle>
-
-          <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
-
-          <VDivider></VDivider>
-
-          <VCardActions>
-            <VSpacer></VSpacer>
-            <VBtn color="primary" text @click="dialog = false"> OK </VBtn>
-          </VCardActions>
-        </VCard>
-      </VDialog>
+      </VCheckbox>
 
       <VCheckbox
         v-for="(title, j) in section.additional"
@@ -152,8 +140,7 @@ export default {
     return {
       selected: null,
       value: null,
-      includedResults: null,
-      dialog: false
+      includedResults: null
     }
   },
   computed: {
@@ -199,6 +186,15 @@ export default {
         value: this.value,
         includedResults: this.includedResults
       })
+    },
+    returnDialog({ clear }) {
+      if (clear) {
+        this.includedResults = this.includedResults.filter(
+          x => x !== 'file-explorer'
+        )
+      } else if (!this.includedResults.includes('file-explorer')) {
+        this.includedResults.push('file-explorer')
+      }
     }
   }
 }

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -36,6 +36,7 @@
             >Individual files (<b>{{ selectedFiles.length }}</b> selected)</span
           >
           <SelectFilesDialog
+            v-if="!readonly"
             :file-manager="fileManager"
             @return="returnDialog"
           />

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -29,7 +29,7 @@
         :readonly="readonly"
         dense
         value="file-explorer"
-        @change="updateConsent"
+        @change="updateFilesCheckbox"
       >
         <template #label>
           <span class="mr-2"
@@ -37,7 +37,9 @@
           >
           <SelectFilesDialog
             v-if="!readonly"
+            ref="selectFilesDialog"
             :file-manager="fileManager"
+            :button-ref="buttonRef"
             @return="returnDialog"
           />
         </template>
@@ -141,7 +143,8 @@ export default {
     return {
       selected: null,
       value: null,
-      includedResults: null
+      includedResults: null,
+      buttonRef: 'selectFilesDialogButton'
     }
   },
   computed: {
@@ -197,6 +200,11 @@ export default {
         this.includedResults.push('file-explorer')
       }
       this.updateConsent()
+    },
+    updateFilesCheckbox() {
+      if (this.includedResults.includes('file-explorer')) {
+        this.$refs.selectFilesDialog.$refs[this.buttonRef].$el.click()
+      }
     }
   }
 }

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -196,6 +196,7 @@ export default {
       } else if (!this.includedResults.includes('file-explorer')) {
         this.includedResults.push('file-explorer')
       }
+      this.updateConsent()
     }
   }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -20,6 +20,7 @@
     "other"
   ],
   "hashtags": ["dataprivacy", "hestialabs"],
+  "filedrop": "https://example.com",
   "consent": {
     "default": [
       {

--- a/vuetify.options.js
+++ b/vuetify.options.js
@@ -16,7 +16,9 @@ import {
   mdiMinusBox,
   mdiStepForward,
   mdiTwitter,
-  mdiMinus
+  mdiMinus,
+  mdiNumeric1CircleOutline,
+  mdiNumeric2CircleOutline
 } from '@mdi/js'
 
 export default {
@@ -39,7 +41,9 @@ export default {
       mdiMinusBox,
       mdiStepForward,
       mdiTwitter,
-      mdiMinus
+      mdiMinus,
+      mdiNumeric1CircleOutline,
+      mdiNumeric2CircleOutline
     }
   },
   theme: {


### PR DESCRIPTION
Changes: As described in #350, **except** for the following:

- The file content can still be browsed because it will soon be necessary for selecting individual data points. However, the file hierarchy is shown by default and clicking on a file doesn't automatically switch to this panel.
- I think that clearing the selection when the user unchecks the box would be a very frustrating experience (easy to misclick). Instead, there is a "Clear selection" button inside the dialog. The checkbox is automatically unchecked when clicking this button.

Note: the dialog has been moved to a separate component