### PR TITLE
feat: table experience and custom audience view (facebook)

### DIFF
--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -66,7 +66,7 @@
       "customPipeline": "jsonToTableConverter",
       "customPipelineOptions": { 
         "rootAccessor": {
-          "fileAccessorRegex": "/ads_information/advertisers_using_your_activity_or_information.json",
+          "fileAccessorRegex": "ads_information/advertisers_using_your_activity_or_information.json",
           "nodeAccessor": "$.custom_audiences_all_types_v2[*]"
         },
         "properties": [
@@ -85,13 +85,13 @@
           {
             "name": "has_remarketing_custom_audience",
             "field": "has_remarketing_custom_audience",
-            "type": "string",
+            "type": "boolean",
             "required": true
           },
           {
             "name": "has_in_person_store_visit",
             "field": "has_in_person_store_visit",
-            "type": "string",
+            "type": "boolean",
             "required": true
           }
         ]

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -68,6 +68,45 @@
       "showTable": false,
       "title": "Dated observations",
       "text": "See all the dated events in your files, corresponding to data that has been collected on you at or concerning a specific date."
+    },
+    {
+      "key": "customAudience",
+      "customPipeline": "jsonToTableConverter",
+      "customPipelineOptions": { 
+        "rootAccessor": {
+          "fileAccessorRegex": "/ads_information/advertisers_using_your_activity_or_information.json",
+          "nodeAccessor": "$.custom_audiences_all_types_v2[*]"
+        },
+        "properties": [
+          {
+            "name": "Advertiser",
+            "field": "advertiser_name",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "has_data_file_custom_audience",
+            "field": "has_data_file_custom_audience",
+            "type": "boolean",
+            "required": true
+          },
+          {
+            "name": "has_remarketing_custom_audience",
+            "field": "has_remarketing_custom_audience",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "has_in_person_store_visit",
+            "field": "has_in_person_store_visit",
+            "type": "string",
+            "required": true
+          }
+        ]
+      },
+      "showTable": true,
+      "title": "Advertisers using your activity or information",
+      "text": "See all advertisers that use Facebook to get information about you"
     }
   ]
 }

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -62,14 +62,6 @@
       "text": "Get a list of advertisers that have uploaded a contact list containing you."
     },
     {
-      "key": "genericDateViewer",
-      "customPipeline": "genericDateViewer",
-      "visualization": "ChartViewGenericDateViewer.vue",
-      "showTable": false,
-      "title": "Dated observations",
-      "text": "See all the dated events in your files, corresponding to data that has been collected on you at or concerning a specific date."
-    },
-    {
       "key": "customAudience",
       "customPipeline": "jsonToTableConverter",
       "customPipelineOptions": { 
@@ -107,6 +99,14 @@
       "showTable": true,
       "title": "Advertisers using your activity or information",
       "text": "See all advertisers that use Facebook to get information about you"
+    },
+    {
+      "key": "genericDateViewer",
+      "customPipeline": "genericDateViewer",
+      "visualization": "ChartViewGenericDateViewer.vue",
+      "showTable": false,
+      "title": "Dated observations",
+      "text": "See all the dated events in your files, corresponding to data that has been collected on you at or concerning a specific date."
     }
   ]
 }

--- a/manifests/experiences/facebook/pipeline.js
+++ b/manifests/experiences/facebook/pipeline.js
@@ -1,7 +1,11 @@
 import {
   genericDateViewer,
-  jsonToTableConverter
+  jsonToTableConverter,
   genericLocationViewer
 } from '~/manifests/generic-pipelines'
 
-export default { genericDateViewer, genericLocationViewer }
+export default {
+  genericDateViewer,
+  jsonToTableConverter,
+  genericLocationViewer
+}

--- a/manifests/experiences/facebook/pipeline.js
+++ b/manifests/experiences/facebook/pipeline.js
@@ -1,3 +1,6 @@
-import { genericDateViewer } from '~/manifests/generic-pipelines'
+import {
+  genericDateViewer,
+  jsonToTableConverter
+} from '~/manifests/generic-pipelines'
 
-export default { genericDateViewer }
+export default { genericDateViewer, jsonToTableConverter }

--- a/manifests/experiences/google/google.json
+++ b/manifests/experiences/google/google.json
@@ -10,7 +10,7 @@
   "timedObservationsViewer": {
     "fileMatchers": [
       {
-        "regex": "Takeout/(?:.+?)/(.+?)/(?:.+?)\\.json",
+        "regex": "(?:.*/)?(.+?)/(?:OmatTapahtumat|MonActivité|My Activity)\\.json",
         "entryPath": "$[*]",
         "fields": {
           "date": {
@@ -126,11 +126,12 @@
       "visualization": "ChartViewTimedObservationsViewer.vue",
       "showTable": false,
       "title": "Overview of what google knows about you",
-      "text": ""
+      "text": "See all dated observations we found in your Google My Activity folder."
     },
     {
       "key": "genericLocationViewer",
       "customPipeline": "genericLocationViewer",
+      "customPipelineOptions": { "acceptedPaths": ".*" },
       "visualization": "ChartViewGenericLocationViewer.vue",
       "showTable": false,
       "title": "Location observations",

--- a/manifests/generic-pipelines.js
+++ b/manifests/generic-pipelines.js
@@ -413,17 +413,28 @@ async function jsonToTableConverter({
                 wrap: true
               })
 
-              // Cast value to specified format, may need to handle errors
               if (value.length === 0) {
                 if (p.required)
                   console.error('value not found for field accessor', p.field)
                 item[p.name] = null
-              } else if (p.type === 'date') {
-                item[p.name] = d3.timeParse(p.format)(value)
-              } else if (p.type === 'number') {
-                item[p.name] = +value
-              } else {
-                item[p.name] = value
+              }
+
+              // Cast value to specified format, may need to handle errors
+              switch (p.type) {
+                case 'date':
+                  item[p.name] = d3.timeParse(p.format)(value)
+                  break
+                case 'string':
+                  item[p.name] = String(value)
+                  break
+                case 'number':
+                  item[p.name] = Number(value)
+                  break
+                case 'boolean':
+                  item[p.name] = Boolean(value)
+                  break
+                default:
+                  item[p.name] = value
               }
             })
             return item

--- a/manifests/jsonToTableSchema.js
+++ b/manifests/jsonToTableSchema.js
@@ -1,0 +1,65 @@
+/**
+ * This schema is a parsed json object in the JsonSchema syntax.
+ * We're using the default syntax of https://ajv.js.org/
+ * It is build to validate the options given to the custom pipeline
+ * jsonToTableConverter
+ */
+export default {
+  type: 'object',
+  properties: {
+    rootAccessor: {
+      type: 'object',
+      properties: {
+        fileAccessorRegex: {
+          type: 'string' // Regex that match a set of files to scan
+        },
+        nodeAccessor: {
+          type: 'string' // JSONPath to access a list of object in those files
+        }
+      },
+      required: ['fileAccessorRegex', 'nodeAccessor']
+    },
+    // here we define the properties of each column
+    properties: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          // name to display for the column
+          name: {
+            type: 'string'
+          },
+          // JSONPath to access the value (it can be nested or not)
+          field: {
+            type: 'string'
+          },
+          // type of the value, allow to cast specific types
+          type: {
+            default: 'object',
+            enum: ['string', 'date', 'number', 'object', 'list', 'boolean']
+          },
+          // format is required when the type is "date",
+          // we use https://github.com/d3/d3-time-format to format dates
+          format: {
+            type: 'string'
+          },
+          // When required is set to true, an error message will be sent
+          // if a value is not found, in any case empty values are set to null
+          required: {
+            type: 'boolean'
+          }
+        },
+        required: ['name', 'field', 'type', 'required'],
+        anyOf: [
+          {
+            not: {
+              properties: { type: { const: 'date' } }
+            }
+          },
+          { required: ['format'] }
+        ]
+      }
+    }
+  },
+  required: ['rootAccessor', 'properties']
+}


### PR DESCRIPTION
This PR is related to https://github.com/hestiaAI/hestialabs-experiences/issues/385 and https://github.com/hestiaAI/hestialabs-experiences/issues/349
Added a new type of pipeline based on accessors. We can create experiments by specifying : 
- a regex to match a set of files: `fileAccessorRegex`
- a jsonPath to access a set of elements in those files: `nodeAccessor`
- a jsonPath for each value/column in those elements: `field`

Here is an example we use for Facebook: 
```
{
      "key": "customAudience",
      "customPipeline": "jsonToTableConverter",
      "customPipelineOptions": { 
        "rootAccessor": {
          "fileAccessorRegex": "/ads_information/advertisers_using_your_activity_or_information.json",
          "nodeAccessor": "$.custom_audiences_all_types_v2[*]"
        },
        "properties": [
          {
            "name": "Advertiser",
            "field": "advertiser_name",
            "type": "string",
            "required": true
          },
          {
            "name": "has_data_file_custom_audience",
            "field": "has_data_file_custom_audience",
            "type": "boolean",
            "required": true
          },
          {
            "name": "has_remarketing_custom_audience",
            "field": "has_remarketing_custom_audience",
            "type": "string",
            "required": true
          },
          {
            "name": "has_in_person_store_visit",
            "field": "has_in_person_store_visit",
            "type": "string",
            "required": true
          }
        ]
      },
      "showTable": true,
      "title": "Advertisers using your activity or information",
      "text": "See all advertisers that use Facebook to get information about you"
    }
```

Note that the customPipelineOptions are validated with a JsonSchema, and we could do this for the entire manifests. 
