### PR TITLE
Improvements and bug fix for file selection

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -40,7 +40,7 @@
         <template v-if="success">
           <VRow v-if="showDataExplorer">
             <VCol>
-              <UnitFileExplorer v-bind="{ fileManager, selectable: false }" />
+              <UnitFileExplorer v-bind="{ fileManager }" />
             </VCol>
           </VRow>
           <VRow

--- a/components/unit/consent-form/SelectFilesDialog.vue
+++ b/components/unit/consent-form/SelectFilesDialog.vue
@@ -1,34 +1,21 @@
 <template>
-  <div>
-    <VDialog v-model="dialog" width="80%" persistent scrollable>
-      <template #activator="{ on }">
-        <BaseButton
-          :ref="buttonRef"
-          class="mb-4"
-          text="Select files"
-          v-on="on"
-        />
-      </template>
+  <VDialog v-model="show" width="80%" persistent scrollable>
+    <VCard>
+      <VCardTitle class="text-h5 grey lighten-2"> Select files </VCardTitle>
+
+      <VCardText style="height: 500px">
+        <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
+      </VCardText>
 
       <VDivider></VDivider>
 
-      <VCard>
-        <VCardTitle class="text-h5 grey lighten-2"> Select files </VCardTitle>
-
-        <VCardText style="height: 500px">
-          <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
-        </VCardText>
-
-        <VDivider></VDivider>
-
-        <VCardActions>
-          <VSpacer></VSpacer>
-          <VBtn color="primary" text @click="clear"> Clear selection </VBtn>
-          <VBtn color="primary" text @click="ok"> OK </VBtn>
-        </VCardActions>
-      </VCard>
-    </VDialog>
-  </div>
+      <VCardActions>
+        <VSpacer></VSpacer>
+        <VBtn color="primary" text @click="clear"> Clear selection </VBtn>
+        <VBtn color="primary" text @click="ok"> OK </VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
 </template>
 
 <script>
@@ -40,29 +27,32 @@ export default {
       type: FileManager,
       required: true
     },
-    buttonRef: {
-      type: String,
-      default: 'selectFilesDialogButton'
-    }
-  },
-  data() {
-    return {
-      dialog: false
+    value: {
+      type: Boolean,
+      required: true
     }
   },
   computed: {
+    show: {
+      get() {
+        return this.value
+      },
+      set(value) {
+        this.$emit('input', value)
+      }
+    },
     key() {
       return this.$route.params.key
     }
   },
   methods: {
     ok() {
-      this.dialog = false
+      this.show = false
       this.$emit('return', { clear: false })
     },
     clear() {
       this.$store.commit('setSelectedFiles', { key: this.key, value: [] })
-      this.dialog = false
+      this.show = false
       this.$emit('return', { clear: true })
     }
   }

--- a/components/unit/consent-form/SelectFilesDialog.vue
+++ b/components/unit/consent-form/SelectFilesDialog.vue
@@ -19,6 +19,7 @@
         <VTreeview
           v-model="selectedFiles"
           dense
+          activatable
           open-on-click
           return-object
           transition
@@ -26,8 +27,10 @@
           selectable
           selected-color="primary"
           :open.sync="openItems"
+          :active.sync="activeItems"
           :search="search"
           :items="treeItems"
+          @update:active="clickOnLabel"
         >
           <template #prepend="{ item }">
             <VIcon>
@@ -64,7 +67,8 @@ export default {
   },
   data() {
     return {
-      search: ''
+      search: '',
+      activeItems: []
     }
   },
   computed: {
@@ -118,6 +122,16 @@ export default {
         tree = tree[0].children ?? []
       }
       this.openItems = open
+    },
+    clickOnLabel(event) {
+      // vuetify doesn't have an option to check/uncheck when clicking the label, this is a workaround
+      const item = event[0]
+      if (this.selectedFiles.includes(item)) {
+        this.selectedFiles = this.selectedFiles.filter(x => x !== item)
+      } else {
+        this.selectedFiles = this.selectedFiles.concat([item])
+      }
+      this.activeItems = []
     }
   }
 }

--- a/components/unit/consent-form/SelectFilesDialog.vue
+++ b/components/unit/consent-form/SelectFilesDialog.vue
@@ -1,10 +1,40 @@
 <template>
-  <VDialog v-model="show" width="80%" persistent scrollable>
+  <VDialog v-model="show" width="500" persistent scrollable>
     <VCard>
       <VCardTitle class="text-h5 grey lighten-2"> Select files </VCardTitle>
 
-      <VCardText style="height: 500px">
-        <UnitFileExplorer v-bind="{ fileManager, selectable: true }" />
+      <VCardText>
+        <VTextField
+          v-model="search"
+          label="Search for files"
+          placeholder="Enter part of a file name..."
+          clearable
+          hide-details
+          prepend-icon="$vuetify.icons.mdiMagnify"
+          class="my-4 pr-3"
+          style="max-width: 500px"
+          outlined
+          dense
+        />
+        <VTreeview
+          v-model="selectedFiles"
+          dense
+          open-on-click
+          return-object
+          transition
+          rounded
+          selectable
+          selected-color="primary"
+          :open.sync="openItems"
+          :search="search"
+          :items="treeItems"
+        >
+          <template #prepend="{ item }">
+            <VIcon>
+              {{ item.icon }}
+            </VIcon>
+          </template>
+        </VTreeview>
       </VCardText>
 
       <VDivider></VDivider>
@@ -32,7 +62,15 @@ export default {
       required: true
     }
   },
+  data() {
+    return {
+      search: ''
+    }
+  },
   computed: {
+    treeItems() {
+      return this.fileManager.getTreeItems()
+    },
     show: {
       get() {
         return this.value
@@ -41,8 +79,24 @@ export default {
         this.$emit('input', value)
       }
     },
+    selectedFiles: {
+      get() {
+        return this.$store.state.selectedFiles[this.key]
+      },
+      set(value) {
+        this.$store.commit('setSelectedFiles', { key: this.key, value })
+      }
+    },
     key() {
       return this.$route.params.key
+    }
+  },
+  watch: {
+    fileManager: {
+      immediate: true,
+      handler() {
+        this.setInitOpen()
+      }
     }
   },
   methods: {
@@ -54,6 +108,16 @@ export default {
       this.$store.commit('setSelectedFiles', { key: this.key, value: [] })
       this.show = false
       this.$emit('return', { clear: true })
+    },
+    setInitOpen() {
+      // If the root has a sequence of nodes with 1 children, pre-open them
+      const open = []
+      let tree = this.treeItems
+      while (tree.length === 1) {
+        open.push(tree[0])
+        tree = tree[0].children ?? []
+      }
+      this.openItems = open
     }
   }
 }

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -32,18 +32,21 @@
         @change="updateFilesCheckbox"
       >
         <template #label>
-          <span class="mr-2"
-            >Individual files (<b>{{ selectedFiles.length }}</b> selected)</span
+          <span
+            >Individual files (<a
+              style="text-decoration: underline"
+              @click="showDialog = true"
+              ><b>{{ selectedFiles.length }}</b> selected</a
+            >)</span
           >
-          <SelectFilesDialog
-            v-if="!readonly"
-            ref="selectFilesDialog"
-            :file-manager="fileManager"
-            :button-ref="buttonRef"
-            @return="returnDialog"
-          />
         </template>
       </VCheckbox>
+      <SelectFilesDialog
+        v-if="!readonly"
+        v-model="showDialog"
+        :file-manager="fileManager"
+        @return="returnDialog"
+      />
 
       <VCheckbox
         v-for="(title, j) in section.additional"
@@ -144,7 +147,7 @@ export default {
       selected: null,
       value: null,
       includedResults: null,
-      buttonRef: 'selectFilesDialogButton'
+      showDialog: false
     }
   },
   computed: {
@@ -203,7 +206,7 @@ export default {
     },
     updateFilesCheckbox() {
       if (this.includedResults.includes('file-explorer')) {
-        this.$refs.selectFilesDialog.$refs[this.buttonRef].$el.click()
+        this.showDialog = true
       }
     }
   }

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -2,7 +2,7 @@
   <VCard
     v-click-outside="{
       handler: () => {
-        if (!selectable) mini = true
+        mini = true
       },
       closeConditional: () => !mini
     }"
@@ -15,7 +15,6 @@
         --cursor-style: wait !important;
       }
     </style>
-    <!-- https://github.com/vuetifyjs/vuetify/issues/5617 -->
     <VNavigationDrawer
       ref="drawer"
       :mini-variant.sync="mini"
@@ -23,10 +22,6 @@
       absolute
       permanent
       width="100%"
-      style="
-        transform: translateX(0) !important;
-        visibility: visible !important;
-      "
     >
       <template #prepend>
         <VListItem class="px-2">
@@ -39,9 +34,6 @@
           <VBtn icon @click.stop="mini = !mini">
             <VIcon>$vuetify.icons.mdiChevronLeft</VIcon>
           </VBtn>
-        </VListItem>
-        <VListItem v-if="selectable && !mini">
-          Size of selected files: {{ selectionSizeString }}
         </VListItem>
         <VListItem v-if="!mini">
           <VTextField
@@ -65,17 +57,14 @@
 
       <div :class="miniWidthPaddingLeftClass">
         <VTreeview
-          v-model="selectedFiles"
           dense
           open-on-click
           activatable
           return-object
           transition
           rounded
-          :selectable="selectable"
           :search="search"
           :items="treeItems"
-          :open.sync="openItems"
           @update:active="setSelectedItem"
         >
           <template #prepend="{ item }">
@@ -86,11 +75,9 @@
         </VTreeview>
       </div>
     </VNavigationDrawer>
-    <VCardTitle v-if="!selectable" class="justify-center"
-      >Explore your files</VCardTitle
-    >
+    <VCardTitle class="justify-center">Explore your files</VCardTitle>
     <div :class="miniWidthPaddingLeftClass">
-      <VCardText v-if="!selectable">
+      <VCardText>
         Analysed <b>{{ nFiles }}</b> {{ plurify('file', nFiles) }} (<b>{{
           dataSizeString
         }}</b
@@ -143,10 +130,6 @@ export default {
     fileManager: {
       type: FileManager,
       required: true
-    },
-    selectable: {
-      type: Boolean,
-      default: false
     }
   },
   data() {
@@ -160,9 +143,7 @@ export default {
       height: 500,
       computeNPoints: false,
       nDataPoints: null,
-      sortedExtensionTexts: [],
-      selectionSize: 0,
-      openItems: []
+      sortedExtensionTexts: []
     }
   },
   computed: {
@@ -175,9 +156,6 @@ export default {
     },
     treeItems() {
       return this.fileManager.getTreeItems()
-    },
-    selectionSizeString() {
-      return humanReadableFileSize(this.selectionSize)
     },
     path() {
       // TODO avoid code duplication with viewer/mixin-path
@@ -232,21 +210,6 @@ export default {
       return _.sortBy(Object.entries(occurrences), ([ext, count]) =>
         ext === 'other' ? 1 : -count
       )
-    },
-    key() {
-      return this.$route.params.key
-    },
-    selectedFiles: {
-      get() {
-        return this.$store.state.selectedFiles[this.key]
-      },
-      set(value) {
-        this.$store.commit('setSelectedFiles', { key: this.key, value })
-        this.selectionSize = _.sumBy(
-          value,
-          ({ filename }) => this.fileManager.fileDict[filename]?.size ?? 0
-        )
-      }
     }
   },
   watch: {
@@ -262,7 +225,6 @@ export default {
         if (this.computeNPoints) {
           this.setNumberOfDataPoints()
         }
-        this.setInitOpen()
       }
     }
   },
@@ -347,16 +309,6 @@ export default {
           files.length > showAtMost ? ' including: ' : ':'
         } ${topFilesDescription}`
       })
-    },
-    setInitOpen() {
-      // If the root has a sequence of nodes with 1 children, pre-open them
-      const open = []
-      let tree = this.treeItems
-      while (tree.length === 1) {
-        open.push(tree[0])
-        tree = tree[0].children ?? []
-      }
-      this.openItems = open
     }
   }
 }

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -89,7 +89,7 @@
       <!-- File explorer -->
       <VRow v-if="hasFileExplorer">
         <VCol>
-          <UnitFileExplorer v-bind="{ fileManager, selectable: false }" />
+          <UnitFileExplorer v-bind="{ fileManager }" />
         </VCol>
       </VRow>
     </template>


### PR DESCRIPTION
Addresses the following comments (via signal):

- why is the popup so wide? I have massive amounts of whitespace at right. Could the width be dynamically decided?
- it feels odd that the file explorer is a separate frame 'within' the select files dialog. any way to make it a bit more integrated?
- File explorer title not needed here.
- As discussed in #350 the details panel and < arrow should be hidden. This dialog should ONLY be for selecting files. Let's not incorporate any of #366 solution into this, that would probably be a separate dialog.
- Editing your selection is a bit weird. I think it would be better if "2 selected" was a link to trigger the dialog (without changing the checkbox).

The last point lets us work around a bug where the "Select files" button did not appear in the instances (but did appear in a local environment).

Based on https://github.com/hestiaAI/hestialabs-experiences/issues/350#issuecomment-999515601, I have decided to stop using the whole FileExplorer component in this popup, because we only need a very small fraction of it.