### PR TITLE
JSON content search

### DIFF
--- a/components/base/BaseSearchBar.vue
+++ b/components/base/BaseSearchBar.vue
@@ -1,0 +1,32 @@
+<template>
+  <VTextField
+    :value="search"
+    prepend-icon="$vuetify.icons.mdiMagnify"
+    :label="label"
+    :placeholder="placeholder"
+    single-line
+    hide-details
+    clearable
+    class="mb-6 mt-3"
+    @input="$emit('input', $event)"
+  ></VTextField>
+</template>
+
+<script>
+export default {
+  props: {
+    search: {
+      type: String,
+      default: ''
+    },
+    label: {
+      type: String,
+      default: 'Search'
+    },
+    placeholder: {
+      type: String,
+      default: 'Type...'
+    }
+  }
+}
+</script>

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerCsv.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerCsv.vue
@@ -4,7 +4,7 @@
     <p>Could not parse file. Showing content instead</p>
     <div class="explorer__content">{{ csvText }}</div>
   </div>
-  <UnitFilterableTable v-else :data="csvContent" />
+  <UnitFilterableTable v-else :data="csvContent" display-filters />
 </template>
 
 <script>

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -57,13 +57,10 @@ export default {
       },
       immediate: true
     },
-    search: {
-      handler() {
-        // The search starts some time after the user stops typing, not after every character typed
-        this.delayedUpdateFilteredItems.clear()
-        this.delayedUpdateFilteredItems()
-      },
-      immediate: true
+    search() {
+      // The search starts some time after the user stops typing, not after every character typed
+      this.delayedUpdateFilteredItems.clear()
+      this.delayedUpdateFilteredItems()
     }
   },
   methods: {

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -30,7 +30,8 @@ import { debounce } from 'debounce'
 
 import mixin from './mixin'
 import mixinLoading from './mixin-loading'
-import itemifyJSON from '~/utils/json'
+import JsonWorker from '~/utils/json.worker.js'
+import { runWorker } from '@/utils/utils'
 
 export default {
   name: 'UnitFileExplorerViewerJson',
@@ -79,20 +80,12 @@ export default {
       }
       this.setLoading(false)
     },
-    filterCondition() {
-      // Returns a function with closure
-      const search = this.search
-      return item => {
-        const searchValue = search.toLowerCase()
-        return (
-          (item.name && `${item.name}`.toLowerCase().includes(searchValue)) ||
-          (item.value && `${item.value}`.toLowerCase().includes(searchValue))
-        )
-      }
-    },
-    updateFilteredItems() {
+    async updateFilteredItems() {
       if (this.search) {
-        this.filteredItems = itemifyJSON(this.jsonText, this.filterCondition())
+        this.filteredItems = await runWorker(new JsonWorker(), {
+          jsonText: this.jsonText,
+          filter: this.search
+        })
       } else {
         this.filteredItems = this.items
       }

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -4,27 +4,31 @@
     <p>Could not parse file. Showing content instead</p>
     <div class="explorer__content">{{ jsonText }}</div>
   </div>
-  <VTreeview v-else dense transition :items="items">
-    <template #prepend="{ item }">
-      <VIcon v-if="!isUndef(item.icon)">
-        {{ item.icon }}
-      </VIcon>
-    </template>
-    <template #label="{ item, leaf }">
-      <div v-if="leaf" :title="item.value">
-        <span v-if="!isUndef(item.name)">
-          {{ `${item.name}:` }}
-        </span>
-        <span class="font-italic">{{ item.value }}</span>
-      </div>
-      <div v-else>{{ item.name }}</div>
-    </template>
-  </VTreeview>
+  <div v-else>
+    <BaseSearchBar v-model="search"></BaseSearchBar>
+    <VTreeview dense transition :items="filteredItems">
+      <template #prepend="{ item }">
+        <VIcon v-if="!isUndef(item.icon)">
+          {{ item.icon }}
+        </VIcon>
+      </template>
+      <template #label="{ item, leaf }">
+        <div v-if="leaf" :title="item.value">
+          <span v-if="!isUndef(item.name)">
+            {{ `${item.name}:` }}
+          </span>
+          <span class="font-italic">{{ item.value }}</span>
+        </div>
+        <div v-else>{{ item.name }}</div>
+      </template>
+    </VTreeview>
+  </div>
 </template>
 
 <script>
 import mixin from './mixin'
 import mixinLoading from './mixin-loading'
+import itemifyJSON from '~/utils/json'
 
 export default {
   name: 'UnitFileExplorerViewerJson',
@@ -33,7 +37,16 @@ export default {
     return {
       jsonText: '',
       items: [],
-      error: false
+      error: false,
+      search: ''
+    }
+  },
+  computed: {
+    filteredItems() {
+      if (this.search) {
+        return itemifyJSON(this.jsonText, this.filterCondition())
+      }
+      return this.items
     }
   },
   watch: {
@@ -58,6 +71,17 @@ export default {
         this.error = true
       }
       this.setLoading(false)
+    },
+    filterCondition() {
+      // Returns a function with closure
+      const search = this.search
+      return item => {
+        const searchValue = search.toLowerCase()
+        return (
+          (item.name && `${item.name}`.toLowerCase().includes(searchValue)) ||
+          (item.value && `${item.value}`.toLowerCase().includes(searchValue))
+        )
+      }
     }
   }
 }

--- a/components/unit/filterable-table/UnitFilterableTableFilter.vue
+++ b/components/unit/filterable-table/UnitFilterableTableFilter.vue
@@ -14,16 +14,7 @@
       hide-details
       menu-props="auto, overflowY, offsetY, top"
     />
-    <VTextField
-      v-model="searchValue"
-      append-icon="mdi-magnify"
-      label="Search"
-      placeholder="Type..."
-      single-line
-      hide-details
-      clearable
-      class="mb-6 mt-3"
-    ></VTextField>
+    <BaseSearchBar v-model="searchValue"></BaseSearchBar>
   </div>
 </template>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "d3-sankey": "^0.12.3",
         "d3-shape": "^3.0.1",
         "dc": "^4.2.7",
+        "debounce": "^1.2.1",
         "jsonpath-plus": "^6.0.1",
         "jszip": "^3.7.1",
         "localforage": "^1.10.0",
@@ -12131,6 +12132,11 @@
     "node_modules/de-indent": {
       "version": "1.0.2",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -37034,6 +37040,11 @@
     "de-indent": {
       "version": "1.0.2",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "d3-sankey": "^0.12.3",
     "d3-shape": "^3.0.1",
     "dc": "^4.2.7",
+    "debounce": "^1.2.1",
     "jsonpath-plus": "^6.0.1",
     "jszip": "^3.7.1",
     "localforage": "^1.10.0",

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -245,7 +245,7 @@ export default class FileManager {
   async getJsonItems(filePath) {
     if (!_.has(this.#jsonItems, filePath)) {
       const text = await this.getPreprocessedText(filePath)
-      const items = await runWorker(new JsonWorker(), text)
+      const items = await runWorker(new JsonWorker(), { jsonText: text })
       this.#jsonItems[filePath] = items
       // this.#jsonItems[filePath] = itemifyJSON(text)
     }

--- a/utils/json.js
+++ b/utils/json.js
@@ -5,6 +5,14 @@ import {
 } from '@mdi/js'
 import _ from 'lodash'
 
+function filterCondition(item, filter) {
+  filter = filter.toLowerCase()
+  return (
+    (item.name && `${item.name}`.toLowerCase().includes(filter)) ||
+    (item.value && `${item.value}`.toLowerCase().includes(filter))
+  )
+}
+
 /**
  * itemifyJSON transforms some JSON into a tree, suitable for a Vuetify VTreeview component.
  * @param {String} jsonText
@@ -12,7 +20,7 @@ import _ from 'lodash'
  * and returning true if the node satifisfies the desired filter condition
  * @returns {Array} the tree
  */
-export default function itemifyJSON(jsonText, filterCondition) {
+export default function itemifyJSON(jsonText, filter) {
   const groupsPerLevel = 10
   let id = 0
   function minifyList(list, base = 0) {
@@ -41,7 +49,7 @@ export default function itemifyJSON(jsonText, filterCondition) {
         const inner = itemifyRec(el)
         if (typeof inner.name === 'undefined') {
           // Leaf node (second part)
-          if (filterCondition && !filterCondition(inner)) {
+          if (filter && !filterCondition(inner, filter)) {
             return []
           }
         }
@@ -66,7 +74,7 @@ export default function itemifyJSON(jsonText, filterCondition) {
         if (typeof inner.name === 'undefined') {
           // Leaf node (second part)
           const leaf = { ...inner, name }
-          if (filterCondition && !filterCondition(leaf)) {
+          if (filter && !filterCondition(leaf, filter)) {
             return []
           }
           return leaf

--- a/utils/json.worker.js
+++ b/utils/json.worker.js
@@ -1,3 +1,4 @@
 import itemifyJSON from '~/utils/json'
 
-onmessage = message => postMessage(itemifyJSON(message.data))
+onmessage = message =>
+  postMessage(itemifyJSON(message.data.jsonText, message.data.filter))


### PR DESCRIPTION
Part of #347 

Changes:
- Add base search bar component
- Display filters in CSV viewer
- Add filter for JSON viewer

Note: there was a feature of `itemifyJSON` that caused objects or array containing only one element to be shrunk into a single node. I removed it, because if we keep it, it often creates elements with too much text that goes out of frame:

![Screenshot_20211223_184409](https://user-images.githubusercontent.com/25420002/147276045-137b803b-0321-41b1-8db7-369d188a234f.png)

Also, it can be confusing to have elements that dynamically move in the hierarchy. But it may be better to put back this feature and solve the problem differently.