### PR TITLE
Feat: edit, test modification of custom pipeline options

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -5,7 +5,7 @@
       :lang="editorLanguage"
       theme="monokai"
       height="500"
-      class="my-ace-editor my-6"
+      class="my-ace-editor"
       @init="initEditor"
     ></AceEditor>
   </client-only>
@@ -83,11 +83,11 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .my-ace-editor {
   /* you can provide font-family font-size line-height. Example: */
   font-family: Fira code, Fira Mono, Consolas, Menlo, Courier, monospace;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.5;
 }
 </style>

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -88,6 +88,7 @@
 <script>
 import { validExtensions } from '~/manifests/utils'
 import FileManager from '~/utils/file-manager'
+import fileManagerWorkers from '~/utils/file-manager-workers'
 import parseYarrrml from '~/utils/parse-yarrrml'
 import rdfUtils from '~/utils/rdf'
 
@@ -182,7 +183,11 @@ export default {
       rml: '',
       allResults: [...Array(this.defaultView.length)],
       allFiles: null,
-      fileManager: new FileManager(this.preprocessors, this.allowMissingFiles),
+      fileManager: new FileManager(
+        this.preprocessors,
+        this.allowMissingFiles,
+        fileManagerWorkers
+      ),
       db: null
     }
   },

--- a/components/unit/UnitCustomPipeline.vue
+++ b/components/unit/UnitCustomPipeline.vue
@@ -10,6 +10,7 @@
       </VCol>
     </VRow>
     <VRow>
+      <VSpacer />
       <VCol align="center">
         <BaseButton
           v-bind="{ progress, status, error }"
@@ -19,12 +20,24 @@
           @click="runPipeline"
         />
       </VCol>
+      <VCol v-if="options">
+        <VSwitch v-model="optionsVisible" label="Edit options" />
+      </VCol>
+      <VSpacer />
     </VRow>
+    <VExpandTransition>
+      <VRow v-show="optionsVisible">
+        <VCol>
+          <CodeEditor :value.sync="options" language="json" />
+        </VCol>
+      </VRow>
+    </VExpandTransition>
   </div>
 </template>
 
 <script>
 import FileManager from '~/utils/file-manager'
+import { setTimeoutPromise } from '@/utils/utils'
 
 export default {
   name: 'UnitCustomPipeline',
@@ -52,31 +65,44 @@ export default {
       error: false,
       progress: false,
       code: '',
-      parameter: ''
+      parameter: '',
+      options: '',
+      optionsVisible: false
+    }
+  },
+  watch: {
+    options() {
+      this.status = false
+    }
+  },
+  mounted() {
+    const optionsObject = this.defaultViewElements.customPipelineOptions
+    if (optionsObject) {
+      this.options = JSON.stringify(optionsObject, null, 2)
     }
   },
   methods: {
-    runPipeline() {
+    async runPipeline() {
       this.error = false
       this.progress = true
-      setTimeout(async () => {
-        try {
-          const result = await this.customPipeline({
-            fileManager: this.fileManager,
-            manifest: this.$store.getters.manifest(this.$route),
-            parameter: this.parameter,
-            options: this.defaultViewElements.customPipelineOptions
-          })
-          this.$emit('update', result)
-        } catch (error) {
-          console.error(error)
-          this.error = true
-          this.$emit('update', { error })
-        } finally {
-          this.status = true
-          this.progress = false
-        }
-      }, 1)
+      await setTimeoutPromise(1)
+      try {
+        const optionsObject = JSON.parse(this.options)
+        const result = await this.customPipeline({
+          fileManager: this.fileManager,
+          manifest: this.$store.getters.manifest(this.$route),
+          parameter: this.parameter,
+          options: optionsObject
+        })
+        this.$emit('update', result)
+      } catch (error) {
+        console.error(error)
+        this.error = true
+        this.$emit('update', { error })
+      } finally {
+        this.status = true
+        this.progress = false
+      }
     }
   }
 }

--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -76,6 +76,7 @@ export default {
         this.filteredItems = this.items
         this.error = false
       } catch (error) {
+        console.error(error)
         this.error = true
       }
       this.setLoading(false)

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -65,9 +65,9 @@
       "key": "customAudience",
       "customPipeline": "jsonToTableConverter",
       "customPipelineOptions": { 
-        "rootAccessor": {
-          "fileAccessorRegex": "ads_information/advertisers_using_your_activity_or_information.json",
-          "nodeAccessor": "$.custom_audiences_all_types_v2[*]"
+        "accessor": {
+          "filePath": "ads_information/advertisers_who_uploaded_a_contact_list_with_your_information.json",
+          "jsonPath": "$.custom_audiences_all_types_v2[*]"
         },
         "properties": [
           {

--- a/manifests/generic-pipelines.js
+++ b/manifests/generic-pipelines.js
@@ -1,26 +1,27 @@
 import { JSONPath } from 'jsonpath-plus'
 import _ from 'lodash'
-import * as d3 from 'd3'
+// don't import the whole of d3 or tests fail
+import { timeParse } from 'd3-time-format'
 import Ajv from 'ajv'
 import jsonToTableSchema from './jsonToTableSchema'
 const ajv = new Ajv()
 
 // Define all accepted date formats
 const timeParsers = [
-  d3.timeParse('%Y-%m-%dT%H:%M:%SZ'),
-  d3.timeParse('%Y-%m-%dT%H:%M:%S.%LZ'),
-  d3.timeParse('%Y-%m-%d %H:%M:%S %Z UTC'),
-  d3.timeParse('%Y-%m-%d %H:%M:%S.%L%Z'),
-  d3.timeParse('%Y-%m-%d %H:%M:%S UTC'),
-  d3.timeParse('%Y-%m-%d %H:%M:%S'),
-  d3.timeParse('%Y-%m-%d %H:%M'),
-  d3.timeParse('%Y-%m-%d %H:%M'),
-  d3.timeParse('%Y-%m-%d'),
-  d3.timeParse('%Y/%m/%d %H:%M:%S'),
-  d3.timeParse('%Y-%m-%dT%H:%M:%S.%LZ[UTC]'),
-  d3.timeParse('%Y-%m-%d %H:%M'),
-  d3.timeParse('%s'), // Unix seconds
-  d3.timeParse('%Q') // Unix milliseconds
+  timeParse('%Y-%m-%dT%H:%M:%SZ'),
+  timeParse('%Y-%m-%dT%H:%M:%S.%LZ'),
+  timeParse('%Y-%m-%d %H:%M:%S %Z UTC'),
+  timeParse('%Y-%m-%d %H:%M:%S.%L%Z'),
+  timeParse('%Y-%m-%d %H:%M:%S UTC'),
+  timeParse('%Y-%m-%d %H:%M:%S'),
+  timeParse('%Y-%m-%d %H:%M'),
+  timeParse('%Y-%m-%d %H:%M'),
+  timeParse('%Y-%m-%d'),
+  timeParse('%Y/%m/%d %H:%M:%S'),
+  timeParse('%Y-%m-%dT%H:%M:%S.%LZ[UTC]'),
+  timeParse('%Y-%m-%d %H:%M'),
+  timeParse('%s'), // Unix seconds
+  timeParse('%Q') // Unix milliseconds
 ]
 
 // Define range of valid year, in case of timestamp date format
@@ -359,9 +360,9 @@ async function genericLocationViewer({ fileManager, options }) {
  * The options are passed with "customPipelineOptions" in the manifest and must
  * follow the JsonShema defined in jsonToTableSchema.js, e.g:
  *  "customPipelineOptions": {
- *      "rootAccessor": {
- *        "fileAccessorRegex": "...", // A regex
- *        "nodeAccessor": "..." // A JsonPath
+ *      "accessor": {
+ *        "filePath": "...", // A file path or glob
+ *        "jsonPath": "..." // A JsonPath
  *      },
  *      "properties": [
  *        {
@@ -397,82 +398,42 @@ async function jsonToTableConverter({
     return {}
   }
 
-  // Get the filenames matching the rootAccessor
-  const filenames = fileManager
-    .getFilenames()
-    .filter(f => new RegExp(options.rootAccessor.fileAccessorRegex).test(f))
-  if (filenames.length === 0) {
-    console.error('no matching files for regex:', options.rootAccessor)
-    return {}
-  }
+  const entries = await fileManager.findMatchingObjects(options.accessor, {
+    freeFiles: true
+  })
 
-  // retreive the headers names
   const headers = options.properties.map(p => p.name)
-  // iterate through all files matched
-  const items = (
-    await Promise.all(
-      filenames.flatMap(async filename => {
-        // read the file
-        const text = Object.values(
-          await fileManager.preprocessFiles([filename])
-        )[0]
-        // Clear file from memory
-        fileManager.freeFile(filename)
-        try {
-          // get all entries that satisfy the given root JSONPATH
-          const entries = JSONPath({
-            path: options.rootAccessor.nodeAccessor,
-            json: JSON.parse(text)
-          })
-          if (entries.length === 0)
-            console.error(
-              'value not found for node accessor',
-              options.rootAccessor.nodeAccessor
-            )
-          // build
-          return entries.map(e => {
-            const item = {}
-            options.properties.forEach(p => {
-              // get all entries that satisfy the given field JSONPATH
-              const value = JSONPath({
-                path: p.field,
-                json: e,
-                wrap: true
-              })
 
-              if (value.length === 0) {
-                if (p.required)
-                  console.error('value not found for field accessor', p.field)
-                item[p.name] = null
-              }
-
-              // Cast value to specified format, may need to handle errors
-              switch (p.type) {
-                case 'date':
-                  item[p.name] = d3.timeParse(p.format)(value)
-                  break
-                case 'string':
-                  item[p.name] = String(value)
-                  break
-                case 'number':
-                  item[p.name] = Number(value)
-                  break
-                case 'boolean':
-                  item[p.name] = Boolean(value)
-                  break
-                default:
-                  item[p.name] = value
-              }
-            })
-            return item
-          })
-        } catch (e) {
-          console.error(e)
-          return []
-        }
+  const items = entries.map(e => {
+    const item = {}
+    options.properties.forEach(p => {
+      // get all entries that satisfy the given field JSONPATH
+      const value = JSONPath({
+        path: p.field,
+        json: e,
+        wrap: true
       })
-    )
-  ).flat()
+
+      // Cast value to specified format, may need to handle errors
+      switch (p.type) {
+        case 'date':
+          item[p.name] = timeParse(p.format)(value)
+          break
+        case 'string':
+          item[p.name] = String(value)
+          break
+        case 'number':
+          item[p.name] = Number(value)
+          break
+        case 'boolean':
+          item[p.name] = Boolean(value)
+          break
+        default:
+          item[p.name] = value
+      }
+    })
+    return item
+  })
   return { headers, items }
 }
 export {

--- a/manifests/generic-pipelines.test.js
+++ b/manifests/generic-pipelines.test.js
@@ -1,0 +1,48 @@
+import { jsonToTableConverter } from '~/manifests/generic-pipelines'
+import { mockFileManager } from '~/utils/file-manager.test'
+
+test('jsonToTableConverter', async () => {
+  const fileName = 'comments_and_reactions/comments.json'
+  const content = {
+    comments_v2: [
+      { timestamp: 1000000000, comment: 'one comment' },
+      { timestamp: 1000000001, comment: 'another comment' }
+    ]
+  }
+  const fileManager = await mockFileManager(fileName, JSON.stringify(content))
+
+  const options = {
+    accessor: {
+      filePath: 'comments_and_reactions/comments.json',
+      jsonPath: '$.comments_v2[*]'
+    },
+    properties: [
+      {
+        name: 'Timestamp',
+        field: 'timestamp',
+        type: 'number',
+        required: true
+      },
+      {
+        name: 'First comment',
+        field: 'comment',
+        type: 'string',
+        required: true
+      }
+    ]
+  }
+
+  expect(fileManager.hasFile(fileName)).toBe(true)
+  const bobo = await fileManager.getText(fileName)
+  expect(bobo).toStrictEqual(JSON.stringify(content))
+
+  const tableData = await jsonToTableConverter({ fileManager, options })
+  const correct = {
+    headers: ['Timestamp', 'First comment'],
+    items: [
+      { Timestamp: 1000000000, 'First comment': 'one comment' },
+      { Timestamp: 1000000001, 'First comment': 'another comment' }
+    ]
+  }
+  expect(tableData).toStrictEqual(correct)
+})

--- a/manifests/generic-pipelines.test.js
+++ b/manifests/generic-pipelines.test.js
@@ -1,12 +1,12 @@
 import { jsonToTableConverter } from '~/manifests/generic-pipelines'
-import { mockFileManager } from '~/utils/file-manager.test'
+import { mockFileManager } from '~/utils/file-manager-mock'
 
-test('jsonToTableConverter', async () => {
+test('jsonToTableConverter with properties', async () => {
   const fileName = 'comments_and_reactions/comments.json'
   const content = {
     comments_v2: [
-      { timestamp: 1000000000, comment: 'one comment' },
-      { timestamp: 1000000001, comment: 'another comment' }
+      { timestamp: 1000000000, comment: 'one comment', name: 'hello' },
+      { timestamp: 1000000001, comment: 'another comment', name: 'toto' }
     ]
   }
   const fileManager = await mockFileManager(fileName, JSON.stringify(content))
@@ -43,6 +43,64 @@ test('jsonToTableConverter', async () => {
       { Timestamp: 1000000000, 'First comment': 'one comment' },
       { Timestamp: 1000000001, 'First comment': 'another comment' }
     ]
+  }
+  expect(tableData).toStrictEqual(correct)
+})
+
+test('jsonToTableConverter without properties', async () => {
+  const fileName = 'comments_and_reactions/comments.json'
+  const content = {
+    comments_v2: [
+      { timestamp: 1000000000, comment: 'one comment', name: 'hello' },
+      { timestamp: 1000000001, comment: 'another comment', name: 'toto' }
+    ]
+  }
+  const fileManager = await mockFileManager(fileName, JSON.stringify(content))
+
+  const options = {
+    accessor: {
+      filePath: 'comments_and_reactions/comments.json',
+      jsonPath: '$.comments_v2[*]'
+    }
+  }
+
+  expect(fileManager.hasFile(fileName)).toBe(true)
+  const bobo = await fileManager.getText(fileName)
+  expect(bobo).toStrictEqual(JSON.stringify(content))
+
+  const tableData = await jsonToTableConverter({ fileManager, options })
+  const correct = {
+    headers: ['timestamp', 'comment', 'name'],
+    items: content.comments_v2
+  }
+  expect(tableData).toStrictEqual(correct)
+})
+
+test('jsonToTableConverter without properties and varying objects', async () => {
+  const fileName = 'comments_and_reactions/comments.json'
+  const content = {
+    comments_v2: [
+      { timestamp: 1000000000, comment: 'one comment' },
+      { timestamp: 1000000001, comment: 'another comment', name: 'hello' }
+    ]
+  }
+  const fileManager = await mockFileManager(fileName, JSON.stringify(content))
+
+  const options = {
+    accessor: {
+      filePath: 'comments_and_reactions/comments.json',
+      jsonPath: '$.comments_v2[*]'
+    }
+  }
+
+  expect(fileManager.hasFile(fileName)).toBe(true)
+  const bobo = await fileManager.getText(fileName)
+  expect(bobo).toStrictEqual(JSON.stringify(content))
+
+  const tableData = await jsonToTableConverter({ fileManager, options })
+  const correct = {
+    headers: ['timestamp', 'comment', 'name'],
+    items: content.comments_v2
   }
   expect(tableData).toStrictEqual(correct)
 })

--- a/manifests/jsonToTableSchema.js
+++ b/manifests/jsonToTableSchema.js
@@ -61,5 +61,5 @@ export default {
       }
     }
   },
-  required: ['accessor', 'properties']
+  required: ['accessor']
 }

--- a/manifests/jsonToTableSchema.js
+++ b/manifests/jsonToTableSchema.js
@@ -7,17 +7,17 @@
 export default {
   type: 'object',
   properties: {
-    rootAccessor: {
+    accessor: {
       type: 'object',
       properties: {
-        fileAccessorRegex: {
+        filePath: {
           type: 'string' // Regex that match a set of files to scan
         },
-        nodeAccessor: {
+        jsonPath: {
           type: 'string' // JSONPath to access a list of object in those files
         }
       },
-      required: ['fileAccessorRegex', 'nodeAccessor']
+      required: ['filePath', 'jsonPath']
     },
     // here we define the properties of each column
     properties: {
@@ -61,5 +61,5 @@ export default {
       }
     }
   },
-  required: ['rootAccessor', 'properties']
+  required: ['accessor', 'properties']
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -157,17 +157,6 @@ export default {
             }
           ]
         },
-        {
-          test: /unzipit-worker.module.js$/,
-          use: [
-            {
-              loader: 'file-loader',
-              options: {
-                name: '[path][name].[contenthash:7].[ext]'
-              }
-            }
-          ]
-        },
         // for importing wasm files
         // https://github.com/sql-js/react-sqljs-demo
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "sha1": "^1.1.1",
         "sparqlalgebrajs": "^4.0.1",
         "sql.js": "^1.6.2",
-        "unzipit": "^1.3.5",
         "vega": "^5.20.2",
         "vega-embed": "^6.18.2",
         "vega-lite": "^5.1.1",
@@ -25322,16 +25321,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/unzipit": {
-      "version": "1.3.5",
-      "integrity": "sha512-GNJVu1nkQYaw9ploGIuXzrP9bE6y+/V748P3RsMn8W0fHEEkecwd+SHwKH9jXOSuBAKTEOqqF66k0GfFQZ1ReA==",
-      "dependencies": {
-        "uzip-module": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/upath": {
       "version": "2.0.1",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
@@ -25483,10 +25472,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/uzip-module": {
-      "version": "1.0.3",
-      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -47137,13 +47122,6 @@
         }
       }
     },
-    "unzipit": {
-      "version": "1.3.5",
-      "integrity": "sha512-GNJVu1nkQYaw9ploGIuXzrP9bE6y+/V748P3RsMn8W0fHEEkecwd+SHwKH9jXOSuBAKTEOqqF66k0GfFQZ1ReA==",
-      "requires": {
-        "uzip-module": "^1.0.2"
-      }
-    },
     "upath": {
       "version": "2.0.1",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w=="
@@ -47258,10 +47236,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "uzip-module": {
-      "version": "1.0.3",
-      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jszip": "^3.7.1",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
-        "minimatch": "^3.0.4",
+        "micromatch": "^4.0.4",
         "n3": "^1.12.1",
         "nuxt": "^2.15.8",
         "regression": "^2.0.1",
@@ -19803,6 +19803,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dependencies": {
         "braces": "^3.0.1",
@@ -42788,6 +42789,7 @@
     },
     "micromatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "requires": {
         "braces": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "d3-collection": "^1.0.7",
         "d3-sankey": "^0.12.3",
         "d3-shape": "^3.0.1",
+        "d3-time-format": "^4.1.0",
         "dc": "^4.2.7",
         "debounce": "^1.2.1",
         "jsonpath-plus": "^6.0.1",
@@ -11697,19 +11698,14 @@
       }
     },
     "node_modules/d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "dependencies": {
-        "d3-time": "1 - 2"
-      }
-    },
-    "node_modules/d3-time-format/node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-      "dependencies": {
-        "d3-array": "2"
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-timer": {
@@ -11875,17 +11871,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3/node_modules/d3-time-format": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.0.0.tgz",
-      "integrity": "sha512-nzaCwlj+ZVBIlFuVOT1RmU+6xb/7D5IcnhHzHQcBgS/aTa5K9fWZNN5LCXA27LgF5WxoSNJqKBbLcGMtM6Ca6A==",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -12099,6 +12084,14 @@
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
+      }
+    },
+    "node_modules/dc/node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dependencies": {
+        "d3-time": "1 - 2"
       }
     },
     "node_modules/dc/node_modules/d3-transition": {
@@ -25642,6 +25635,22 @@
         "vega-util": "^1.15.2"
       }
     },
+    "node_modules/vega-format/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/vega-format/node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
     "node_modules/vega-functions": {
       "version": "5.12.0",
       "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.0.tgz",
@@ -25809,6 +25818,14 @@
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
+      }
+    },
+    "node_modules/vega-scale/node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dependencies": {
+        "d3-time": "1 - 2"
       }
     },
     "node_modules/vega-scenegraph": {
@@ -36501,14 +36518,6 @@
           "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
           "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
         },
-        "d3-time-format": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.0.0.tgz",
-          "integrity": "sha512-nzaCwlj+ZVBIlFuVOT1RmU+6xb/7D5IcnhHzHQcBgS/aTa5K9fWZNN5LCXA27LgF5WxoSNJqKBbLcGMtM6Ca6A==",
-          "requires": {
-            "d3-time": "1 - 3"
-          }
-        },
         "d3-timer": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
@@ -36776,21 +36785,11 @@
       }
     },
     "d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "requires": {
-        "d3-time": "1 - 2"
-      },
-      "dependencies": {
-        "d3-time": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-          "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-          "requires": {
-            "d3-array": "2"
-          }
-        }
+        "d3-time": "1 - 3"
       }
     },
     "d3-timer": {
@@ -36995,6 +36994,14 @@
           "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
           "requires": {
             "d3-array": "2"
+          }
+        },
+        "d3-time-format": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+          "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+          "requires": {
+            "d3-time": "1 - 2"
           }
         },
         "d3-transition": {
@@ -47393,6 +47400,24 @@
         "d3-time-format": "^3.0.0",
         "vega-time": "^2.0.3",
         "vega-util": "^1.15.2"
+      },
+      "dependencies": {
+        "d3-time": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+          "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+          "requires": {
+            "d3-array": "2"
+          }
+        },
+        "d3-time-format": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+          "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+          "requires": {
+            "d3-time": "1 - 2"
+          }
+        }
       }
     },
     "vega-functions": {
@@ -47550,6 +47575,14 @@
           "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
           "requires": {
             "d3-array": "2"
+          }
+        },
+        "d3-time-format": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+          "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+          "requires": {
+            "d3-time": "1 - 2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jszip": "^3.7.1",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
-    "minimatch": "^3.0.4",
+    "micromatch": "^4.0.4",
     "n3": "^1.12.1",
     "nuxt": "^2.15.8",
     "regression": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "sha1": "^1.1.1",
     "sparqlalgebrajs": "^4.0.1",
     "sql.js": "^1.6.2",
-    "unzipit": "^1.3.5",
     "vega": "^5.20.2",
     "vega-embed": "^6.18.2",
     "vega-lite": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,21 @@
     "transform": {
       "^.+\\.[t|j]sx?$": "babel-jest",
       "^.+\\.vue$": "@vue/vue2-jest"
-    }
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!d3)",
+      "\\.pnp\\.[^\\/]+$"
+    ]
   },
+  "_transformIgnorePatterns": [
+    "/node_modules/(?!robust-predicates)",
+    "/node_modules/(?!d3)",
+    "/node_modules/",
+    "node_modules/(?!(d3.*|robust-predicates)/)",
+    "node_modules/(?!(robust-predicates)/)",
+    "node_modules/(?!(d3.*)/)",
+    "\\.pnp\\.[^\\/]+$"
+  ],
   "lint-staged": {
     "*.{js,vue}": "npm run lint"
   },
@@ -60,6 +73,7 @@
     "d3-collection": "^1.0.7",
     "d3-sankey": "^0.12.3",
     "d3-shape": "^3.0.1",
+    "d3-time-format": "^4.1.0",
     "dc": "^4.2.7",
     "debounce": "^1.2.1",
     "jsonpath-plus": "^6.0.1",

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -99,6 +99,7 @@
 <script>
 import JSZip from 'jszip'
 import FileManager from '~/utils/file-manager'
+import fileManagerWorkers from '~/utils/file-manager-workers'
 
 export default {
   data() {
@@ -191,7 +192,11 @@ export default {
         const files = folderContent.map(
           (r, i) => new File([blobs[i]], r.name.substr(6))
         )
-        this.fileManager = new FileManager(this.manifest.preprocessors)
+        this.fileManager = new FileManager(
+          this.manifest.preprocessors,
+          false,
+          fileManagerWorkers
+        )
         await this.fileManager.init(files, true)
       } catch (error) {
         this.handleError(

--- a/utils/accessor.js
+++ b/utils/accessor.js
@@ -1,13 +1,13 @@
-import { posix } from 'path'
+import path from 'path'
 import { JSONPath } from 'jsonpath-plus'
-import minimatch from 'minimatch'
+import micromatch from 'micromatch'
 import Ajv from 'ajv'
 const ajv = new Ajv()
-const path = posix
+const posixPath = path.posix || path
 
 export function matchNormalized(name, pattern) {
-  const normalizedPattern = path.normalize(pattern)
-  return minimatch(name, normalizedPattern)
+  const normalizedPattern = posixPath.normalize(pattern)
+  return micromatch.isMatch(name, normalizedPattern)
 }
 
 /**

--- a/utils/accessor.test.js
+++ b/utils/accessor.test.js
@@ -1,11 +1,11 @@
 import { posix } from 'path'
 import { JSONPath } from 'jsonpath-plus'
-import minimatch from 'minimatch'
+import micromatch from 'micromatch'
 import Ajv from 'ajv'
 import { matchNormalized, findMatches } from './accessor'
 
 const ajv = new Ajv()
-const path = posix
+const posixPath = posix
 
 function findObjects(fileDict, accessor) {
   return Object.entries(fileDict)
@@ -20,12 +20,18 @@ function matchFiles(files, pattern) {
 }
 
 test('normalize and match', () => {
-  expect(minimatch('bar.foo', '*.foo')).toBe(true)
-  expect(path.normalize('/foo//baz/asdf/quux/..')).toBe('/foo/baz/asdf')
-  expect(path.normalize('/foo//**/asdf/quux/..')).toBe('/foo/**/asdf')
-  expect(path.normalize('foo/**//asdf/quux/..')).toBe('foo/**/asdf')
+  expect(micromatch.isMatch('bar.foo', '*.foo')).toBe(true)
+  expect(posixPath.normalize('/a/b/../bar.foo')).toBe('/a/bar.foo')
+  expect(posixPath.normalize('/foo//baz/asdf/quux/..')).toBe('/foo/baz/asdf')
+  expect(posixPath.normalize('/foo//**/asdf/quux/..')).toBe('/foo/**/asdf')
+  expect(posixPath.normalize('foo/**//asdf/quux/..')).toBe('foo/**/asdf')
+  expect(posixPath.normalize('/foo//**/{a,s}f/quux/..')).toBe('/foo/**/{a,s}f')
+  expect(posixPath.normalize('/foo//**/[:]}f/quux/..')).toBe('/foo/**/[:]}f')
 
+  expect(matchNormalized('/a/bar.foo', '/a/b/../bar.foo')).toBe(true)
   expect(matchNormalized('bar.foo', '*.foo')).toBe(true)
+  expect(matchNormalized('bar.foo', '*.fo{o,a}')).toBe(true)
+  expect(matchNormalized('bar.fo{o,a}', '*.fo\\{o,a\\}')).toBe(true)
   expect(matchNormalized('/foo/asdf', '/foo//asdf/quux/..')).toBe(true)
   expect(matchNormalized('/foo/bar.foo', '/foo//asdf/../*.foo')).toBe(true)
 })

--- a/utils/file-manager-mock.js
+++ b/utils/file-manager-mock.js
@@ -1,0 +1,13 @@
+import FileManager from '~/utils/file-manager'
+
+export function mockFile(fileName, content) {
+  // browser files are different from node files
+  return { name: fileName, text: () => Promise.resolve(content) }
+}
+
+export async function mockFileManager(fileName, content) {
+  const fileManager = new FileManager({}, true)
+  const file = mockFile(fileName, content)
+  await fileManager.init([file], true)
+  return fileManager
+}

--- a/utils/file-manager-workers.js
+++ b/utils/file-manager-workers.js
@@ -1,0 +1,9 @@
+// the workers are in a separate file
+// so we can run tests with node
+// that somehow can't deal with this syntax
+// given by the worker-loader
+// https://v4.webpack.js.org/loaders/worker-loader/
+import CsvWorker from '~/utils/csv.worker.js'
+import JsonWorker from '~/utils/json.worker.js'
+
+export default { CsvWorker, JsonWorker }

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -258,6 +258,10 @@ export default class FileManager {
   /**
    * Return all matching objects from json files.
    * @param {Object} accessor
+   * @param {Object} options
+   *
+   * Options can have the following attributes:
+   * - freeFiles: true means files are freed after reading
    */
   async findMatchingObjects(accessor, options = {}) {
     const objectPromises = this.getFilenames()

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -1,5 +1,3 @@
-import { setOptions } from 'unzipit'
-import workerURL from 'unzipit/dist/unzipit-worker.module.js'
 import JSZip from 'jszip'
 import {
   mdiCodeJson,
@@ -14,9 +12,8 @@ import {
 } from '@mdi/js'
 import _ from 'lodash'
 import { matchNormalized, findMatchesInContent } from './accessor'
-import CsvWorker from '~/utils/csv.worker.js'
-import { nJsonPoints } from '~/utils/json'
-import JsonWorker from '~/utils/json.worker.js'
+import itemifyJSON, { nJsonPoints } from '~/utils/json'
+import getCsvHeadersAndItems from '~/utils/csv'
 import { runWorker } from '@/utils/utils'
 
 const filetype2icon = {
@@ -47,11 +44,6 @@ const extension2filetype = {
   csv: 'csv',
   tsv: 'csv'
 }
-
-setOptions({
-  workerURL,
-  numWorkers: 2
-})
 
 /**
  * A class that allows to manage the pipeline of files.
@@ -86,7 +78,7 @@ export default class FileManager {
    * @param {Object} preprocessors maps file name to preprocessor function
    * @param {Boolean} allowMissingFiles
    */
-  constructor(preprocessors, allowMissingFiles = false) {
+  constructor(preprocessors, allowMissingFiles = false, workers) {
     this.supportedExtensions = new Set([
       ...Object.keys(extension2filetype),
       ...Object.values(extension2filetype)
@@ -94,6 +86,7 @@ export default class FileManager {
     this.preprocessors = preprocessors ?? {}
     this.allowMissingFiles = allowMissingFiles
     this.setInitialValues()
+    this.workers = workers
   }
 
   /**
@@ -230,8 +223,13 @@ export default class FileManager {
   async getCsvItems(filePath) {
     if (!_.has(this.#csvItems, filePath)) {
       const text = await this.getPreprocessedText(filePath)
-      const items = await runWorker(new CsvWorker(), text)
-      // const items = await getCsvHeadersAndItems(text)
+      const CsvWorker = this.workers?.CsvWorker
+      let items
+      if (CsvWorker) {
+        items = await runWorker(new CsvWorker(), text)
+      } else {
+        items = await getCsvHeadersAndItems(text)
+      }
       this.#csvItems[filePath] = items
     }
     return this.#csvItems[filePath]
@@ -245,9 +243,14 @@ export default class FileManager {
   async getJsonItems(filePath) {
     if (!_.has(this.#jsonItems, filePath)) {
       const text = await this.getPreprocessedText(filePath)
-      const items = await runWorker(new JsonWorker(), [text])
+      const JsonWorker = this.workers?.JsonWorker
+      let items
+      if (JsonWorker) {
+        items = await runWorker(new JsonWorker(), [text])
+      } else {
+        items = itemifyJSON(text)
+      }
       this.#jsonItems[filePath] = items
-      // this.#jsonItems[filePath] = itemifyJSON(text)
     }
     return this.#jsonItems[filePath]
   }
@@ -256,15 +259,24 @@ export default class FileManager {
    * Return all matching objects from json files.
    * @param {Object} accessor
    */
-  async findMatchingObjects(accessor) {
-    const fileContentPromises = Object.keys(this.fileDict)
+  async findMatchingObjects(accessor, options = {}) {
+    const objectPromises = this.getFilenames()
       .filter(filePath => matchNormalized(filePath, accessor.filePath))
-      .map(filePath => this.getJsonItems(filePath))
-    const fileContents = await Promise.all(fileContentPromises)
-    return fileContents
-      .map(content => findMatchesInContent(content, accessor))
-      .filter(m => m)
-      .flatMap()
+      .flatMap(async fileName => {
+        try {
+          const text = await this.getPreprocessedText(fileName)
+          const content = JSON.parse(text)
+          if (options?.freeFiles) {
+            this.freeFile(fileName)
+          }
+          const found = findMatchesInContent(content, accessor)
+          return found
+        } catch (error) {
+          console.error('error during matching', error)
+        }
+      })
+    const objects = await Promise.all(objectPromises)
+    return objects.filter(m => m).flat()
   }
 
   /**

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -1,16 +1,5 @@
 import FileManager from '~/utils/file-manager'
-
-function mockFile(fileName, content) {
-  // browser files are different from node files
-  return { name: fileName, text: () => Promise.resolve(content) }
-}
-
-export async function mockFileManager(fileName, content) {
-  const fileManager = new FileManager({}, true)
-  const file = mockFile(fileName, content)
-  await fileManager.init([file], true)
-  return fileManager
-}
+import { mockFile } from '~/utils/file-manager-mock'
 
 test('an empty file manager', async () => {
   const fileManager = new FileManager({}, true)

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -1,16 +1,23 @@
 import FileManager from '~/utils/file-manager'
 
+function mockFile(fileName, content) {
+  // browser files are different from node files
+  return { name: fileName, text: () => Promise.resolve(content) }
+}
+
+export async function mockFileManager(fileName, content) {
+  const fileManager = new FileManager({}, true)
+  const file = mockFile(fileName, content)
+  await fileManager.init([file], true)
+  return fileManager
+}
+
 test('an empty file manager', async () => {
   const fileManager = new FileManager({}, true)
   fileManager.init([], false)
   const bobo = await fileManager.getText('bobo.json')
   expect(bobo).toStrictEqual('{}')
 })
-
-function mockFile(fileName, content) {
-  // browser files are different from node files
-  return { name: fileName, text: () => Promise.resolve(content) }
-}
 
 test('a json file in file manager', async () => {
   const fileManager = new FileManager({}, true)

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -1,0 +1,45 @@
+import FileManager from '~/utils/file-manager'
+
+test('an empty file manager', async () => {
+  const fileManager = new FileManager({}, true)
+  fileManager.init([], false)
+  const bobo = await fileManager.getText('bobo.json')
+  expect(bobo).toStrictEqual('{}')
+})
+
+function mockFile(fileName, content) {
+  // browser files are different from node files
+  return { name: fileName, text: () => Promise.resolve(content) }
+}
+
+test('a json file in file manager', async () => {
+  const fileManager = new FileManager({}, true)
+  const fileName = 'bibi/bobo.json'
+  const file = mockFile(fileName, '{"hello": 1}')
+  await fileManager.init([file], true)
+
+  expect(fileManager.hasFile(fileName)).toBe(true)
+  const bobo = await fileManager.getText(fileName)
+  expect(bobo).toStrictEqual('{"hello": 1}')
+})
+
+test('findMatchingObjects', async () => {
+  const fileManager = new FileManager({}, true)
+  const fileName = 'bibi/bubo.json'
+  const fileContent = '{"hello": [11,22,33]}'
+  const file = mockFile(fileName, fileContent)
+  await fileManager.init([file], true)
+
+  expect(fileManager.hasFile(fileName)).toBe(true)
+  const bobo = await fileManager.getText(fileName)
+  expect(bobo).toStrictEqual(fileContent)
+
+  let accessor = { filePath: '**/bu*o.json' }
+  let matching = await fileManager.findMatchingObjects(accessor)
+  const jsonContent = JSON.parse(fileContent)
+  expect(matching[0]).toStrictEqual(jsonContent)
+
+  accessor = { filePath: '**/bu*o.json', jsonPath: 'hello[1]' }
+  matching = await fileManager.findMatchingObjects(accessor)
+  expect(matching[0]).toStrictEqual(22)
+})

--- a/utils/json.test.js
+++ b/utils/json.test.js
@@ -1,0 +1,252 @@
+import { JSONPath } from 'jsonpath-plus'
+import {
+  mdiCodeJson,
+  mdiFormatListBulletedSquare,
+  mdiInformationOutline
+} from '@mdi/js'
+import itemifyJSON from '~/utils/json'
+
+const ic = mdiCodeJson
+const is = mdiFormatListBulletedSquare
+const ii = mdiInformationOutline
+
+test('simple itemifyJSON', () => {
+  const json = { n: 'root' }
+  const correctItems = [
+    {
+      icon: ic,
+      id: 2,
+      jsonPath: '$',
+      name: '{attributes N}',
+      children: [
+        { id: 2, jsonPath: "$['n']", value: 'root', icon: ii, name: 'N' }
+      ]
+    }
+  ]
+  const items = itemifyJSON(JSON.stringify(json))
+
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('complex itemifyJSON', () => {
+  const json = {
+    n: 'root',
+    a: { n: 'child', b: [{ c: 1, d: 'roro' }, { c: 2 }, 'meuh'] }
+  }
+  const correctItems = [
+    {
+      icon: ic,
+      id: 11,
+      name: '{attributes N, A}',
+      jsonPath: '$',
+      children: [
+        { id: 2, jsonPath: "$['n']", value: 'root', icon: ii, name: 'N' },
+        {
+          icon: ic,
+          id: 11,
+          name: 'A / {attributes N, B}',
+          jsonPath: "$['a']",
+          children: [
+            {
+              icon: ii,
+              id: 4,
+              jsonPath: "$['a']['n']",
+              name: 'N',
+              value: 'child'
+            },
+            {
+              icon: is,
+              id: 11,
+              name: 'B / [list with 3 items]',
+              jsonPath: "$['a']['b']",
+              children: [
+                {
+                  children: [
+                    {
+                      icon: ii,
+                      id: 7,
+                      jsonPath: "$['a']['b'][0]['c']",
+                      name: 'C',
+                      value: 1
+                    },
+                    {
+                      icon: ii,
+                      id: 8,
+                      jsonPath: "$['a']['b'][0]['d']",
+                      name: 'D',
+                      value: 'roro'
+                    }
+                  ],
+                  icon: ic,
+                  id: 8,
+                  jsonPath: "$['a']['b'][0]",
+                  name: '{attributes C, D}'
+                },
+                {
+                  children: [
+                    {
+                      icon: ii,
+                      id: 10,
+                      jsonPath: "$['a']['b'][1]['c']",
+                      name: 'C',
+                      value: 2
+                    }
+                  ],
+                  icon: ic,
+                  id: 10,
+                  jsonPath: "$['a']['b'][1]",
+                  name: '{attributes C}'
+                },
+                {
+                  icon: ii,
+                  id: 11,
+                  jsonPath: "$['a']['b'][2]",
+                  value: 'meuh'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSON(JSON.stringify(json))
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('item JsonPath for object', () => {
+  const json = { a: { b: 'roro' } }
+  const correctItems = [
+    {
+      icon: ic,
+      id: 3,
+      name: '{attributes A}',
+      jsonPath: '$',
+      children: [
+        {
+          icon: ic,
+          id: 3,
+          jsonPath: "$['a']",
+          name: 'A / {attributes B}',
+          children: [
+            {
+              icon: ii,
+              id: 3,
+              name: 'B',
+              jsonPath: "$['a']['b']",
+              value: 'roro'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSON(JSON.stringify(json))
+  expect(items).toStrictEqual(correctItems)
+
+  const obj = items[0].children[0].children[0]
+
+  expect(obj.jsonPath).toStrictEqual("$['a']['b']")
+  expect(JSONPath({ path: obj.jsonPath, json })).toStrictEqual([json.a.b])
+})
+
+test('item JsonPath for array element', () => {
+  const json = { c: ['toto'] }
+  const correctItems = [
+    {
+      icon: ic,
+      id: 3,
+      name: '{attributes C}',
+      jsonPath: '$',
+      children: [
+        {
+          icon: is,
+          id: 3,
+          name: 'C / [list with 1 item]',
+          jsonPath: "$['c']",
+          children: [
+            {
+              icon: ii,
+              id: 3,
+              jsonPath: "$['c'][0]",
+              value: 'toto'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSON(JSON.stringify(json))
+  expect(items).toStrictEqual(correctItems)
+
+  const arrayEl = items[0].children[0].children[0]
+  expect(arrayEl.jsonPath).toStrictEqual("$['c'][0]")
+  expect(JSONPath({ path: arrayEl.jsonPath, json })).toStrictEqual([json.c[0]])
+})
+
+test('item JsonPath for big array element', () => {
+  const json = {
+    c: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  }
+  const correctItems = [
+    {
+      icon: ic,
+      id: 16,
+      name: '{attributes C}',
+      jsonPath: '$',
+      children: [
+        {
+          id: 14,
+          icon: is,
+          jsonPath: "$['c']",
+          name: 'C / [list with 12 items]',
+          children: [
+            {
+              id: 15,
+              icon: is,
+              name: '[elements 1 - 10]',
+              jsonPath: "$['c']",
+              children: [
+                { id: 3, value: 1, icon: ii, jsonPath: "$['c'][0]" },
+                { id: 4, value: 2, icon: ii, jsonPath: "$['c'][1]" },
+                { id: 5, value: 3, icon: ii, jsonPath: "$['c'][2]" },
+                { id: 6, value: 4, icon: ii, jsonPath: "$['c'][3]" },
+                { id: 7, value: 5, icon: ii, jsonPath: "$['c'][4]" },
+                { id: 8, value: 6, icon: ii, jsonPath: "$['c'][5]" },
+                { id: 9, value: 7, icon: ii, jsonPath: "$['c'][6]" },
+                { id: 10, value: 8, icon: ii, jsonPath: "$['c'][7]" },
+                { id: 11, value: 9, icon: ii, jsonPath: "$['c'][8]" },
+                { id: 12, value: 10, icon: ii, jsonPath: "$['c'][9]" }
+              ]
+            },
+            {
+              id: 16,
+              icon: is,
+              name: '[elements 11 - 12]',
+              jsonPath: "$['c']",
+              children: [
+                { id: 13, value: 11, icon: ii, jsonPath: "$['c'][10]" },
+                { id: 14, value: 12, icon: ii, jsonPath: "$['c'][11]" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSON(JSON.stringify(json))
+  expect(items).toStrictEqual(correctItems)
+
+  const array = items[0].children[0]
+  const subArray0 = array.children[0]
+
+  const arrayPath0 = subArray0.children[5].jsonPath
+  expect(arrayPath0).toStrictEqual("$['c'][5]")
+  expect(JSONPath({ path: arrayPath0, json })).toStrictEqual([json.c[5]])
+
+  const subArray1 = array.children[1]
+
+  const arrayPath1 = subArray1.children[1].jsonPath
+  expect(arrayPath1).toStrictEqual("$['c'][11]")
+  expect(JSONPath({ path: arrayPath1, json })).toStrictEqual([json.c[11]])
+})

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -101,3 +101,6 @@ export function runWorker(worker, args) {
     })
   })
 }
+
+export const setTimeoutPromise = (delay, value) =>
+  new Promise(resolve => setTimeout(resolve, delay, value))


### PR DESCRIPTION
Any pipeline that has custom options gets a switch called "Edit options" next to the run button. Switching it on opens an editor for the options. The pipeline can be run again with the modified options. This adresses most of #400

I didn't have time to add the relatively similar functionality of displaying a table when the user clicks a node in the json viewer #408. I got as far as adding a jsonPath to every item displayed in the tree view.