### PR TITLE
fix: missing checkbox for old exported zips

### DIFF
--- a/components/unit/consent-form/ShowFilesDialog.vue
+++ b/components/unit/consent-form/ShowFilesDialog.vue
@@ -1,0 +1,49 @@
+<template>
+  <VDialog v-model="show" width="500" persistent scrollable>
+    <VCard>
+      <VCardTitle class="text-h5 grey lighten-2"> Selected files </VCardTitle>
+
+      <VCardText>
+        <ul>
+          <li v-for="file in Object.keys(fileManager.fileDict)" :key="file">
+            {{ file }}
+          </li>
+        </ul>
+      </VCardText>
+
+      <VDivider></VDivider>
+
+      <VCardActions>
+        <VSpacer></VSpacer>
+        <VBtn color="primary" text @click="show = false"> Close </VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
+</template>
+
+<script>
+import FileManager from '~/utils/file-manager.js'
+
+export default {
+  props: {
+    fileManager: {
+      type: FileManager,
+      required: true
+    },
+    value: {
+      type: Boolean,
+      required: true
+    }
+  },
+  computed: {
+    show: {
+      get() {
+        return this.value
+      },
+      set(value) {
+        this.$emit('input', value)
+      }
+    }
+  }
+}
+</script>

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -47,6 +47,11 @@
         :file-manager="fileManager"
         @return="returnDialog"
       />
+      <ShowFilesDialog
+        v-else
+        v-model="showDialog"
+        :file-manager="fileManager"
+      />
 
       <VCheckbox
         v-for="(title, j) in section.additional"

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -226,6 +226,15 @@ export default {
           }
         }
       }
+      // If individual files are included, the user gave consent for these.
+      // But in older zips, it wasn't presented as a checkbox.
+      // This change is unfortunately not tied to a version number
+      if (this.fileManager.fileList.length !== 0) {
+        const section = this.consent.find(section => section.type === 'data')
+        if (!('file-explorer' in section.includedResults)) {
+          section.includedResults.push('file-explorer')
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
#417

- Automatically check the "individual files" checkbox if files are included in the zip
- Add a dialog on import for viewing the list of included files