### PR TITLE
feat: top row graph + scoped style for all graphs

### DIFF
--- a/components/chart/ChartView.vue
+++ b/components/chart/ChartView.vue
@@ -61,3 +61,6 @@ export default {
   }
 }
 </script>
+<style>
+@import 'assets/styles/dc.css';
+</style>

--- a/components/chart/view/ChartViewGenericDateViewer.vue
+++ b/components/chart/view/ChartViewGenericDateViewer.vue
@@ -309,11 +309,11 @@ export default {
   }
 }
 </script>
-<style>
-.range-chart > svg > g > g.axis.y {
+<style scoped>
+::v-deep .range-chart > svg > g > g.axis.y {
   display: none;
 }
-.hide {
+::v-deep .hide {
   display: none;
 }
 </style>

--- a/components/chart/view/ChartViewOverviewNetflix.vue
+++ b/components/chart/view/ChartViewOverviewNetflix.vue
@@ -564,32 +564,30 @@ export default {
   }
 }
 </script>
-<style>
-@import 'assets/styles/dc.css';
-
-body {
+<style scoped>
+::v-deep body {
   font-family: sans-serif;
   color: #22313f;
 }
 
-.dc-chart g.row text {
+::v-deep .dc-chart g.row text {
   fill: #22313f;
   font-weight: bold;
 }
 
-.range-chart > svg > g > g.axis.y {
+::v-deep .range-chart > svg > g > g.axis.y {
   display: none;
 }
 
-.reset {
+::v-deep .reset {
   margin-left: 1rem;
 }
 
-.v-application a.reset {
+::v-deep .v-application a.reset {
   color: rgb(85, 3, 30);
 }
 
-p.filters {
+::v-deep p.filters {
   font-size: 0.8rem;
   font-style: italic;
 }

--- a/components/chart/view/ChartViewOverviewTwitter.vue
+++ b/components/chart/view/ChartViewOverviewTwitter.vue
@@ -430,32 +430,32 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 @import 'assets/styles/dc.css';
 
-body {
+::v-deep body {
   font-family: sans-serif;
   color: #22313f;
 }
 
-.dc-chart g.row text {
+::v-deep .dc-chart g.row text {
   fill: #22313f;
   font-weight: bold;
 }
 
-.range-chart > svg > g > g.axis.y {
+::v-deep .range-chart > svg > g > g.axis.y {
   display: none;
 }
 
-.reset {
+::v-deep .reset {
   margin-left: 1rem;
 }
 
-.v-application a.reset {
+::v-deep .v-application a.reset {
   color: rgb(85, 3, 30);
 }
 
-p.filters {
+::v-deep p.filters {
   font-size: 0.8rem;
   font-style: italic;
 }

--- a/components/chart/view/ChartViewOverviewUber.vue
+++ b/components/chart/view/ChartViewOverviewUber.vue
@@ -565,66 +565,66 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 @import 'assets/styles/dc.css';
 
-body {
+::v-deep body {
   font-family: sans-serif;
   color: #22313f;
 }
 
-.dc-chart g.row text {
+::v-deep .dc-chart g.row text {
   fill: #22313f;
   font-weight: bold;
 }
 
-#hour-chart g.y {
+::v-deep #hour-chart g.y {
   display: none;
 }
 
-.reset {
+::v-deep .reset {
   margin-left: 1rem;
 }
 
-.v-application a.reset {
+::v-deep .v-application a.reset {
   color: rgb(85, 3, 30);
 }
 
-p.filters {
+::v-deep p.filters {
   font-size: 0.8rem;
   font-style: italic;
 }
 
-ul.list-inline {
+::v-deep ul.list-inline {
   list-style: none;
   padding-left: 0;
 }
 
-ul.list-inline > li {
+::v-deep ul.list-inline > li {
   display: inline-block;
 }
 
-li.border-right {
+::v-deep li.border-right {
   border-right: 1px solid #90a4ae;
 }
 
-.pl-2 {
+::v-deep .pl-2 {
   padding-left: 1.5rem;
 }
-.pr-2 {
+::v-deep .pr-2 {
   padding-right: 1.5rem;
 }
 
-.stat-info {
+::v-deep .stat-info {
   font-style: italic;
   font-size: 0.8em;
 }
-p.stat-title {
+::v-deep p.stat-title {
   margin: 0.5rem;
   padding: 0;
 }
 
-.stat-elem {
+::v-deep .stat-elem {
   padding: 1rem;
 }
 </style>

--- a/components/chart/view/ChartViewSankey.vue
+++ b/components/chart/view/ChartViewSankey.vue
@@ -307,27 +307,33 @@ export default {
   }
 }
 </script>
-<style>
-body {
+<style scoped>
+::v-deep body {
   font-family: 'Roboto';
   color: #22313f;
 }
 
-.node rect {
+::v-deep .node rect {
   fill-opacity: 0.9;
   shape-rendering: crispEdges;
 }
 
-.node text {
+::v-deep .node text {
   pointer-events: none;
   text-shadow: 0 1px 0 #fff;
 }
 
-.link {
+::v-deep .link {
   fill: none;
   stroke: rgb(87, 86, 87);
 }
 
+::v-deep .label {
+  font-size: 1.1rem;
+  font-weight: bold;
+}
+</style>
+<style>
 .tooltip {
   font-size: 0.7rem;
   background-color: white;
@@ -354,10 +360,5 @@ body {
   border-right: 8px solid white;
   left: -9px;
   top: 7px;
-}
-
-.label {
-  font-size: 1.1rem;
-  font-weight: bold;
 }
 </style>

--- a/components/chart/view/ChartViewSankey.vue
+++ b/components/chart/view/ChartViewSankey.vue
@@ -332,9 +332,8 @@ export default {
   font-size: 1.1rem;
   font-weight: bold;
 }
-</style>
-<style>
-.tooltip {
+
+::v-deep .tooltip {
   font-size: 0.7rem;
   background-color: white;
   border: solid white;
@@ -349,7 +348,7 @@ export default {
   moz-box-shadow: 0px 0px 10px grey;
   box-shadow: 0px 0px 10px grey;
 }
-.tooltip:before {
+::v-deep .tooltip:before {
   content: '';
   display: block;
   width: 0;

--- a/components/chart/view/ChartViewSunburst.vue
+++ b/components/chart/view/ChartViewSunburst.vue
@@ -3,7 +3,7 @@
     <VRow>
       <VCol cols="12" md="12" class="text-center">
         <div :id="graphId">
-          <VBreadcrumbs :items="bcItems" class="breadCrumb" />
+          <VBreadcrumbs :items="bcItems" large />
         </div>
       </VCol>
     </VRow>
@@ -351,12 +351,9 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 body {
   font-family: 'Roboto';
   color: #22313f;
-}
-.breadCrumb.v-breadcrumbs li {
-  font-size: 1.2rem;
 }
 </style>

--- a/components/chart/view/ChartViewTimeSeries.vue
+++ b/components/chart/view/ChartViewTimeSeries.vue
@@ -17,7 +17,7 @@
       </VRow>
       <VRow dense>
         <VCol cols="12">
-          <div :id="graphId"></div>
+          <div :id="graphId" style="position: relative"></div>
         </VCol>
       </VRow>
     </VCol>
@@ -271,17 +271,17 @@ export default {
       })
 
       /* Tooltip */
-      d3.select('#' + this.graphId + '.tooltip').remove()
+      d3.select('#' + this.graphId + ' div.tooltip').remove()
       const tooltip = d3
-        .select('body')
+        .select('#' + this.graphId)
         .append('div')
         .attr('class', 'tooltip')
-        .attr('id', this.graphId)
         .style('opacity', 0)
 
       const that = this
       const f = d3.format(this.valueFormat)
       function showTooltip(evt, d) {
+        const svgDim = svg.node().getBoundingClientRect()
         tooltip.transition().duration(60).style('opacity', 0.98)
         tooltip
           .html(
@@ -290,8 +290,17 @@ export default {
               '</b><br/>' +
               f(d.value)
           ) // d.name
-          .style('left', evt.pageX - 55 + 'px')
-          .style('top', evt.pageY - 45 + 'px')
+          .style(
+            'left',
+            (xScale(new Date(d.key)) - 10) *
+              (svgDim.width / (width + 2 * adj)) +
+              'px'
+          )
+          .style(
+            'top',
+            yScale(d.value) * (svgDim.height / (height + 2 * adj)) + 'px'
+          )
+        console.log(d)
       }
 
       function hideTooltip() {
@@ -412,9 +421,7 @@ export default {
   stroke-opacity: 0.5;
   stroke-width: 10;
 }
-</style>
-<style>
-div.tooltip {
+::v-deep div.tooltip {
   position: absolute;
   text-align: center;
   width: 110px;

--- a/components/chart/view/ChartViewTimeSeries.vue
+++ b/components/chart/view/ChartViewTimeSeries.vue
@@ -376,43 +376,44 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 /* AXES */
 /* ticks */
-.xAxis line,
-.yAxis line {
+::v-deep .xAxis line,
+::v-deep .yAxis line {
   stroke: #706f6f;
   stroke-width: 0.5;
   shape-rendering: geometricPrecision;
 }
 
 /* axis contour */
-.xAxis path,
-.yAxis path {
+::v-deep .xAxis path,
+::v-deep .yAxis path {
   stroke: #706f6f;
   stroke-width: 0.7;
   shape-rendering: geometricPrecision;
 }
 
-.yAxis path {
+::v-deep .yAxis path {
   display: none;
 }
 
 /* axis text */
-.xAxis text,
-.yAxis text {
+::v-deep .xAxis text,
+::v-deep .yAxis text {
   fill: #2b2929;
   font-size: 1rem;
   font-weight: 300;
 }
 
-.gridline {
+::v-deep .gridline {
   stroke: lightgray;
   shape-rendering: geometricPrecision;
   stroke-opacity: 0.5;
   stroke-width: 10;
 }
-
+</style>
+<style>
 div.tooltip {
   position: absolute;
   text-align: center;

--- a/components/chart/view/ChartViewTimedObservationsViewer.vue
+++ b/components/chart/view/ChartViewTimedObservationsViewer.vue
@@ -496,11 +496,11 @@ export default {
   }
 }
 </script>
-<style>
-.range-chart > svg > g > g.axis.y {
+<style scoped>
+::v-deep .range-chart > svg > g > g.axis.y {
   display: none;
 }
-.brush .custom-brush-handle {
+::v-deep .brush .custom-brush-handle {
   display: auto;
 }
 </style>

--- a/components/chart/view/ChartViewTopRow.vue
+++ b/components/chart/view/ChartViewTopRow.vue
@@ -134,6 +134,7 @@ export default {
       )
       // Create/update bars
       const bars = this.svg.selectAll('.bars').data(newData, d => d.key)
+      const that = this
       bars
         .enter()
         .append('rect')
@@ -143,34 +144,22 @@ export default {
         .attr('width', 0)
         .attr('height', this.yScale.bandwidth())
         .attr('fill', '#69b3a2')
-        .on('mouseover', (evt, d) => {
-          d3.select(evt.currentTarget).style('opacity', 0.7)
-          // d3.select(evt.currentTarget).append('text').text('test')
-          this.tooltip
-            .html('<div>' + d.value + '</div>')
-            .style('opacity', 1)
-            .style('font-size', 3 / Math.log(this.topKSlider) + 'rem')
-            .style(
-              'top',
-              this.yScale(d.key) +
-                this.adjVertical +
-                this.padding +
-                this.margin +
-                'px'
-            )
-            .style(
-              'left',
-              this.xScale(d.value) +
-                this.adjHorizontal +
-                this.padding +
-                this.margin +
-                25 +
-                'px'
-            )
+        .on('mouseover', function (evt, d) {
+          d3.select(this).style('opacity', 0.7)
+          d3.select(this.parentNode)
+            .append('text')
+            .attr('class', 'barsLabel')
+            .text(d.value)
+            .attr('text-anchor', 'start')
+            .attr('alignment-baseline', 'middle')
+            .attr('x', that.xScale(d.value) + 15)
+            .attr('y', that.yScale(d.key) + that.yScale.bandwidth() / 2)
+            .style('font-size', '0.8rem')
+            .style('font-weight', 'bold')
         })
-        .on('mouseleave', (evt, d) => {
-          d3.select(evt.currentTarget).style('opacity', 1)
-          this.tooltip.style('opacity', 0)
+        .on('mouseleave', function (evt, d) {
+          d3.select(this).style('opacity', 1)
+          d3.select('.barsLabel').remove()
         })
         .merge(bars)
         .transition()
@@ -281,13 +270,6 @@ export default {
         .style('text-anchor', 'middle')
         .text(this.yLabel)
       this.svg.append('g').attr('class', 'yAxis').call(yAxis)
-
-      // Tooltip
-      this.tooltip = d3
-        .select('#' + this.graphId)
-        .append('div')
-        .attr('class', 'tooltipLabel')
-        .style('opacity', 0)
       this.draw()
     }
   }
@@ -325,8 +307,5 @@ export default {
   fill: #2b2929;
   font-weight: 300;
   font-size: 1rem;
-}
-::v-deep .tooltipLabel {
-  position: absolute;
 }
 </style>

--- a/components/chart/view/ChartViewTopRow.vue
+++ b/components/chart/view/ChartViewTopRow.vue
@@ -199,9 +199,6 @@ export default {
       const formatDate = d3.timeFormat('%B %d, %Y')
       const parseDate = d3.timeParse(this.dateFormat)
       const extent = d3.extent(this.values, d => {
-        console.log(d.date)
-        console.log(this.dateFormat)
-        console.log(parseDate(d.date))
         return parseDate(d.date)
       })
       this.minDate = formatDate(extent[0])

--- a/components/chart/view/ChartViewTopRow.vue
+++ b/components/chart/view/ChartViewTopRow.vue
@@ -1,0 +1,42 @@
+<template>
+  <VContainer>
+    <VRow>
+      <VCol cols="12" md="12" class="text-center">
+        <p>
+          You have been targeted by <strong>{{ total }}</strong> ads between
+          15/04/2021 and 13/06/2021
+        </p>
+        <div :id="graphId"></div>
+      </VCol>
+    </VRow>
+  </VContainer>
+</template>
+
+<script>
+import mixin from './mixin'
+// import * as d3 from 'd3'
+
+export default {
+  mixins: [mixin],
+  props: {
+    dateFormat: {
+      type: String,
+      default: () => '%Y-%m-%d'
+    }
+  },
+  data() {
+    return {
+      total: 0
+    }
+  },
+  mounted() {
+    this.drawViz()
+  },
+  methods: {
+    drawViz() {
+      console.log(this.values)
+    }
+  }
+}
+</script>
+<style scoped></style>

--- a/components/chart/view/ChartViewTopRow.vue
+++ b/components/chart/view/ChartViewTopRow.vue
@@ -9,7 +9,7 @@
       </VCol>
     </VRow>
     <VRow dense justify="center" class="mt-3">
-      <VCol cols="12" md="4">
+      <VCol cols="12" md="3">
         <VSlider
           v-model="topKSlider"
           label="N° of advertisers"
@@ -29,11 +29,10 @@
           v-model="othersCheck"
           dense
           label="Display Others"
-          hide-details
           @change="draw"
         ></VCheckbox>
       </VCol>
-      <VCol cols="6" md="2">
+      <VCol v-if="averageButton" cols="6" md="2">
         <VSelect
           v-model="agg"
           :items="aggList"
@@ -85,12 +84,16 @@ export default {
       default: () => 5
     },
     adjVertical: {
-      type: Number,
-      default: () => 60
+      type: Array,
+      default: () => [20, 50]
     },
     adjHorizontal: {
-      type: Number,
-      default: () => 150
+      type: Array,
+      default: () => [150, 150]
+    },
+    averageButton: {
+      type: Boolean,
+      default: () => false
     }
   },
   data() {
@@ -156,6 +159,7 @@ export default {
             .attr('y', that.yScale(d.key) + that.yScale.bandwidth() / 2)
             .style('font-size', '0.8rem')
             .style('font-weight', 'bold')
+            .style('fill', '#0A0A0A')
         })
         .on('mouseleave', function (evt, d) {
           d3.select(this).style('opacity', 1)
@@ -220,7 +224,7 @@ export default {
 
       /* create svg element */
       const width = 300
-      const height = 480
+      const height = 380
       d3.select('#' + this.graphId + ' svg').remove()
       this.svg = d3
         .select('#' + this.graphId)
@@ -229,13 +233,13 @@ export default {
         .attr(
           'viewBox',
           '-' +
-            this.adjHorizontal +
+            this.adjHorizontal[0] +
             ' -' +
-            this.adjVertical +
+            this.adjVertical[0] +
             ' ' +
-            (width + this.adjHorizontal * 2) +
+            (width + d3.sum(this.adjHorizontal)) +
             ' ' +
-            (height + this.adjVertical * 2)
+            (height + d3.sum(this.adjVertical))
         )
         .style('padding', this.padding)
         .style('margin', this.margin)

--- a/components/chart/view/ChartViewTopRow.vue
+++ b/components/chart/view/ChartViewTopRow.vue
@@ -3,7 +3,7 @@
     <VRow>
       <VCol cols="12" md="12" class="text-center">
         <p>
-          You have been targeted by <strong>{{ total }}</strong> ads between
+          We found <strong>{{ total }}</strong> {{ xLabel }} between
           <strong>{{ minDate }}</strong> and <strong>{{ maxDate }}</strong>
         </p>
       </VCol>
@@ -67,10 +67,6 @@ export default {
       type: String,
       default: () => '~s'
     },
-    yLabel: {
-      type: String,
-      default: () => 'Count'
-    },
     yAxisMaxTickLength: {
       type: Number,
       default: () => 20
@@ -94,6 +90,14 @@ export default {
     averageButton: {
       type: Boolean,
       default: () => false
+    },
+    dateFormat: {
+      type: String,
+      default: () => '%Y-%m-%d'
+    },
+    xLabel: {
+      type: String,
+      default: () => 'records'
     }
   },
   data() {
@@ -193,7 +197,13 @@ export default {
     drawViz() {
       // Compute date range
       const formatDate = d3.timeFormat('%B %d, %Y')
-      const extent = d3.extent(this.values, d => new Date(d.date))
+      const parseDate = d3.timeParse(this.dateFormat)
+      const extent = d3.extent(this.values, d => {
+        console.log(d.date)
+        console.log(this.dateFormat)
+        console.log(parseDate(d.date))
+        return parseDate(d.date)
+      })
       this.minDate = formatDate(extent[0])
       this.maxDate = formatDate(extent[1])
       this.nbDay = d3.timeDay.count(extent[0], extent[1])
@@ -272,7 +282,7 @@ export default {
         .attr('y', 30)
         .attr('x', width / 2)
         .style('text-anchor', 'middle')
-        .text(this.yLabel)
+        .text(this.xLabel)
       this.svg.append('g').attr('class', 'yAxis').call(yAxis)
       this.draw()
     }

--- a/components/chart/view/ChartViewTrackerControl.vue
+++ b/components/chart/view/ChartViewTrackerControl.vue
@@ -439,32 +439,32 @@ export default {
   }
 }
 </script>
-<style>
+<style scoped>
 @import 'assets/styles/dc.css';
 
-body {
+::v-deep body {
   font-family: sans-serif;
   color: #22313f;
 }
 
-.dc-chart g.row text {
+::v-deep .dc-chart g.row text {
   fill: #22313f;
   font-weight: bold;
 }
 
-#range-chart g.y {
+::v-deep #range-chart g.y {
   display: none;
 }
 
-.reset {
+::v-deep .reset {
   margin-left: 1rem;
 }
 
-.v-application a.reset {
+::v-deep .v-application a.reset {
   color: rgb(85, 3, 30);
 }
 
-p.filters {
+::v-deep p.filters {
   font-size: 0.8rem;
   font-style: italic;
 }

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -26,7 +26,10 @@
     {
       "key": "off-facebook-activity-count",
       "sql": "off-facebook-activity-count",
-      "visualization": "top-k-advertisers",
+      "visualization": "ChartViewTopRow.vue",
+      "vizProps": {
+        "dateFormat": "%s"
+      },
       "showTable": false,
       "title": "Off Facebook activity ranking",
       "text": "See how many times third parties have informed Facebook of your activity outside of Facebook."

--- a/manifests/experiences/twitter/twitter.json
+++ b/manifests/experiences/twitter/twitter.json
@@ -20,7 +20,10 @@
       "key": "advertisers-per-day",
       "sql": "advertisers-per-day",
       "visualization": "ChartViewTopRow.vue",
-      "showTable": true,
+      "vizProps": {
+        "xLabel": "ads"
+      },
+      "showTable": false,
       "title": "Top advertisers",
       "text": "See the ranking of advertisers that have shown you the most ads."
     },

--- a/manifests/experiences/twitter/twitter.json
+++ b/manifests/experiences/twitter/twitter.json
@@ -19,8 +19,8 @@
     {
       "key": "advertisers-per-day",
       "sql": "advertisers-per-day",
-      "visualization": "top-k-advertisers",
-      "showTable": false,
+      "visualization": "ChartViewTopRow.vue",
+      "showTable": true,
       "title": "Top advertisers",
       "text": "See the ranking of advertisers that have shown you the most ads."
     },


### PR DESCRIPTION
- Added a new chart for top-k bar charts to replace the old vega one. You can test it on the Twitter experience (top advertiser) : 
![image](https://user-images.githubusercontent.com/17878016/148069613-090704f9-ddfb-4d68-9256-4a4045ab629a.png)
- Fixed several issues we had with overlapping styles between graphics using <style scoped>, this introduced a lot of problems with tooltips but they should all be fixed with this PR. Note that for style inside SVG content we need to prefix them with ```::v-deep``` otherwise they are not applied when used with <style scoped>.