### PR TITLE
fix: z-index issues

### DIFF
--- a/components/TheAppBar.vue
+++ b/components/TheAppBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <VAppBar fixed app color="white" height="75">
+    <VAppBar fixed app color="white" height="75" style="z-index: 2500">
       <VAppBarNavIcon
         aria-label="Open navigation menu"
         @click.stop="drawer = !drawer"

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -22,6 +22,7 @@
       absolute
       permanent
       width="100%"
+      style="z-index: 1000"
     >
       <template #prepend>
         <VListItem class="px-2">

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -78,22 +78,27 @@
     </VNavigationDrawer>
     <VCardTitle class="justify-center">Explore your files</VCardTitle>
     <div :class="miniWidthPaddingLeftClass">
-      <VCardText>
-        Analysed <b>{{ nFiles }}</b> {{ plurify('file', nFiles) }} (<b>{{
-          dataSizeString
-        }}</b
-        >)
-        <template v-if="nDataPoints">
-          and found <b>{{ nDataPoints.toLocaleString() }}</b> datapoints
-        </template>
-        :
-        <ul v-if="sortedExtensionTexts">
-          <li v-for="(text, i) in sortedExtensionTexts" :key="i">
-            <!-- eslint-disable-next-line vue/no-v-html -->
-            <div v-html="text"></div>
-          </li>
-        </ul>
-      </VCardText>
+      <VExpansionPanels v-model="summaryPanelActive" multiple>
+        <VExpansionPanel>
+          <VExpansionPanelHeader> Summary </VExpansionPanelHeader>
+          <VExpansionPanelContent>
+            Analysed <b>{{ nFiles }}</b> {{ plurify('file', nFiles) }} (<b>{{
+              dataSizeString
+            }}</b
+            >)
+            <template v-if="nDataPoints">
+              and found <b>{{ nDataPoints.toLocaleString() }}</b> datapoints
+            </template>
+            :
+            <ul v-if="sortedExtensionTexts">
+              <li v-for="(text, i) in sortedExtensionTexts" :key="i">
+                <!-- eslint-disable-next-line vue/no-v-html -->
+                <div v-html="text"></div>
+              </li>
+            </ul>
+          </VExpansionPanelContent>
+        </VExpansionPanel>
+      </VExpansionPanels>
       <VCardText>
         <template v-if="filename">
           <div class="mr-2">
@@ -139,6 +144,7 @@ export default {
       supportedTypes: new Set(['json', 'csv', 'pdf', 'img', 'html', 'txt']),
       mini: !this.selectable,
       miniWidth: 48,
+      summaryPanelActive: [0],
       search: '',
       isFileLoading: false,
       height: 500,


### PR DESCRIPTION
#407

The table header no longer goes over the navigation drawer. I did it by setting the z-index attribute.

At the same time, I'm suggesting to put the summary string in an expandable panel, as illustrated below, because it can take a lot of screen space. It is open by default, and the user can close it when they start exploring the files content.

![Screenshot_20220105_103529](https://user-images.githubusercontent.com/25420002/148195872-72547085-c784-42fe-93c9-419dbf088000.png)

![Screenshot_20220105_103559](https://user-images.githubusercontent.com/25420002/148195888-f03bb34e-8f01-4872-ada5-d05437f62db6.png)

We can revert this commit if you don't like it