### PR TITLE
refactor: results passed to consent form

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -77,14 +77,12 @@
                   index,
                   vega
                 }"
-                @update="onQueryUpdate"
               />
             </VTabItem>
             <VTabItem v-if="consentForm">
               <UnitConsentForm
                 v-bind="{
                   consentForm,
-                  allResults,
                   defaultView,
                   fileManager,
                   showDataExplorer
@@ -195,8 +193,6 @@ export default {
       success: false,
       message: '',
       rml: '',
-      allResults: [...Array(this.defaultView.length)],
-      allFiles: null,
       fileManager: new FileManager(
         this.preprocessors,
         this.allowMissingFiles,
@@ -279,12 +275,6 @@ export default {
 
       const elapsed = new Date() - start
       this.message = `Successfully processed in ${elapsed / 1000} sec.`
-    },
-    onQueryUpdate({ index, result }) {
-      // we need to change the object or vue won't see the change
-      const newResults = this.allResults.slice()
-      newResults[index] = JSON.stringify(result)
-      this.allResults = newResults
     }
   }
 }

--- a/components/unit/UnitQuery.vue
+++ b/components/unit/UnitQuery.vue
@@ -32,7 +32,7 @@
           />
           <UnitSparql
             v-else
-            v-bind="{ sparqlQuery, queryDisabled }"
+            v-bind="{ sparqlQuery }"
             class="mr-lg-6"
             @update="onUnitResultsUpdate"
           />
@@ -87,10 +87,6 @@ export default {
     defaultViewElements: {
       type: Object,
       default: null
-    },
-    queryDisabled: {
-      type: Boolean,
-      default: false
     },
     index: {
       type: Number,

--- a/components/unit/UnitQuery.vue
+++ b/components/unit/UnitQuery.vue
@@ -45,16 +45,20 @@
               <UnitVegaViz
                 v-if="vizVega"
                 :spec-file="vizVega"
-                :data="result"
+                :data="clonedResult"
                 class="text-center"
               />
               <ChartView
                 v-else-if="vizVue"
                 :graph-name="vizVue"
-                :data="result"
+                :data="clonedResult"
                 :viz-props="defaultViewElements.vizProps"
               />
-              <UnitIframe v-else-if="vizUrl" :src="vizUrl" :data="result" />
+              <UnitIframe
+                v-else-if="vizUrl"
+                :src="vizUrl"
+                :data="clonedResult"
+              />
             </VCol>
           </VRow>
           <VRow v-if="showTable">
@@ -115,7 +119,6 @@ export default {
   },
   data() {
     return {
-      result: undefined,
       finished: false
     }
   },
@@ -135,6 +138,23 @@ export default {
     vizVega() {
       return this.vega[this.vizName]
     },
+    result: {
+      get() {
+        return this.$store.state.results[this.$route.params.key][
+          this.defaultViewElements.key
+        ]
+      },
+      set(result) {
+        this.$store.commit('setResult', {
+          company: this.$route.params.key,
+          experience: this.defaultViewElements.key,
+          result
+        })
+      }
+    },
+    clonedResult() {
+      return JSON.parse(JSON.stringify(this.result))
+    },
     hasData() {
       return this.result && (this.result.headers?.length ?? 1) > 0
     }
@@ -148,10 +168,6 @@ export default {
       }
       this.result = result
       this.finished = true
-      this.$emit('update', { index: this.index, result })
-    },
-    onChangeSelector(query) {
-      this.$emit('change', query)
     }
   }
 }

--- a/components/unit/UnitSparql.vue
+++ b/components/unit/UnitSparql.vue
@@ -21,16 +21,11 @@ export default {
   props: {
     sparqlQuery: {
       type: String,
-      default: null
-    },
-    queryDisabled: {
-      type: Boolean,
-      default: false
+      default: ''
     }
   },
   data() {
     return {
-      queryParameter: '',
       status: false,
       error: false,
       progress: false
@@ -38,7 +33,7 @@ export default {
   },
   computed: {
     disabled() {
-      return !this.sparqlQuery || this.queryDisabled
+      return !this.sparqlQuery
     }
   },
   methods: {

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -183,14 +183,6 @@ export default {
         2
       )}${padNumber(date.getUTCMinutes(), 2)}_UTC.zip`
       return filename
-    },
-    tooBig() {
-      const limit = this.config.formSizeLimitMegaBytes
-      if (!limit) {
-        return false
-      }
-      const megabyte = 1048576
-      return this.encryptedZipFile.length > limit * megabyte
     }
   },
   watch: {

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -13,14 +13,14 @@
 
     <template v-if="section.type === 'data' && !section.hide">
       <VCheckbox
-        v-for="(title, j) in section.titles"
+        v-for="(k, j) in section.keys"
         :key="`data-${j}`"
         v-model="includedResults"
         :readonly="readonly"
         dense
-        :disabled="dataCheckboxDisabled[j]"
-        :label="title"
-        :value="section.keys[j]"
+        :disabled="!!dataCheckboxDisabled[k]"
+        :label="section.titles[j]"
+        :value="k"
         @change="updateConsent"
       ></VCheckbox>
 
@@ -135,8 +135,8 @@ export default {
       default: false
     },
     dataCheckboxDisabled: {
-      type: Array,
-      default: () => []
+      type: Object,
+      default: () => {}
     },
     showDataExplorer: {
       type: Boolean,

--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,6 @@
     "amazon",
     "apple",
     "facebook",
-    "facebook-test",
     "google",
     "spotify",
     "netflix",
@@ -13,10 +12,8 @@
     "youtube",
     "playground",
     "uber",
-    "uber-kepler",
     "ad-radar",
     "explorer",
-    "google-my-activity",
     "other"
   ],
   "hashtags": ["dataprivacy", "hestialabs"],

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -45,7 +45,11 @@
           <UnitConsentFormSection
             v-for="(section, index) in consent"
             :key="`section-${index}`"
-            v-bind="{ section, index, readonly: true, fileManager }"
+            :section="section"
+            :index="index"
+            readonly
+            :file-manager="fileManager"
+            :data-checkbox-disabled="{}"
           />
         </VCardText>
       </VCard>

--- a/store/index.js
+++ b/store/index.js
@@ -6,7 +6,15 @@ export const state = () => ({
     ...config
   },
   manifestMap,
-  selectedFiles: Object.fromEntries(Object.keys(manifestMap).map(k => [k, []]))
+  selectedFiles: Object.fromEntries(config.experiences.map(k => [k, []])),
+  results: Object.fromEntries(
+    config.experiences.map(k => [
+      k,
+      Object.fromEntries(
+        manifestMap[k].defaultView?.map(b => [b.key, null]) ?? []
+      )
+    ])
+  )
 })
 
 export const getters = {
@@ -44,5 +52,8 @@ export const getters = {
 export const mutations = {
   setSelectedFiles(state, { key, value }) {
     state.selectedFiles[key] = value
+  },
+  setResult(state, { company, experience, result }) {
+    state.results[company][experience] = result
   }
 }


### PR DESCRIPTION
Put the results in the store instead of passing them to a sibling component via events and props (`UnitQuery` -> `TheDataExperience` -> `UnitConsentForm`).

Vuex detected that some d3 graphs modify the result objects (e.g. `CharViewSearchSunburst`), so I cloned them before passing them to the graphs.

Also removed some old forgotten code.

I still find the consent form code to be quite messy (especially `UnitConsentFormSection`) but I'm not sure how it could be improved.