### PR TITLE
feat: txt viewer switch to json or csv

### DIFF
--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerTxt.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerTxt.vue
@@ -1,9 +1,36 @@
 <template>
-  <div>
-    <b>Text file content:</b>
-    <hr class="mb-4" />
-    {{ text }}
-  </div>
+  <VContainer>
+    <VRow>
+      <VCol>
+        <VSelect
+          v-model="show"
+          item-text="name"
+          item-value="value"
+          :items="items"
+          label="View as"
+          hide-details
+          style="max-width: 200px"
+        ></VSelect>
+      </VCol>
+    </VRow>
+    <VRow>
+      <VCol>
+        <div v-if="show === 'txt'">
+          <b>Text file content:</b>
+          <hr class="mb-4" />
+          {{ text }}
+        </div>
+        <UnitFileExplorerViewerCsv
+          v-if="show === 'csv'"
+          v-bind="{ fileManager, filename }"
+        />
+        <UnitFileExplorerViewerJson
+          v-if="show === 'json'"
+          v-bind="{ fileManager, filename }"
+        />
+      </VCol>
+    </VRow>
+  </VContainer>
 </template>
 
 <script>
@@ -14,7 +41,13 @@ export default {
   mixins: [mixin],
   data() {
     return {
-      text: ''
+      text: '',
+      show: 'txt',
+      items: [
+        { name: 'Text', value: 'txt' },
+        { name: 'CSV', value: 'csv' },
+        { name: 'JSON', value: 'json' }
+      ]
     }
   },
   watch: {


### PR DESCRIPTION
#373

It adds a selector to switch between plaintext, JSON, or CSV mode when viewing a  `.txt` file

![Screenshot_20220112_180512](https://user-images.githubusercontent.com/25420002/149187593-7b52f976-b247-428d-966a-3cf16916afda.png)

