### PR TITLE
fix: run preprocessor on all files

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -141,9 +141,9 @@ export default {
       type: Boolean,
       default: false
     },
-    preprocessors: {
-      type: Object,
-      default: () => {}
+    preprocessor: {
+      type: Function,
+      default: undefined
     },
     postprocessors: {
       type: Object,
@@ -195,7 +195,7 @@ export default {
       message: '',
       rml: '',
       fileManager: new FileManager(
-        this.preprocessors,
+        this.preprocessor,
         this.allowMissingFiles,
         fileManagerWorkers
       ),

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -10,12 +10,7 @@
     "ads_information/advertisers_you've_interacted_with.json",
     "ads_information/advertisers_who_uploaded_a_contact_list_with_your_information.json"
   ],
-  "preprocessors": {
-    "apps_and_websites_off_of_facebook/your_off-facebook_activity.json": "facebook",
-    "your_topics/your_topics.json": "facebook",
-    "ads_information/advertisers_you've_interacted_with.json": "facebook",
-    "ads_information/advertisers_who_uploaded_a_contact_list_with_your_information.json": "facebook"
-  },
+  "preprocessor": "facebook",
   "allowMissingFiles": true,
   "collaborator": {
     "title": "The Eyeballs Collective",

--- a/manifests/experiences/tinder/tinder.json
+++ b/manifests/experiences/tinder/tinder.json
@@ -5,9 +5,7 @@
   "ext": "json",
   "data": ["tinder-synthetic.json"],
   "files": ["input.json"],
-  "preprocessors": {
-    "input.json": "tinder"
-  },
+  "preprocessor": "tinder",
   "collaborator": {
     "title": "The Dating Privacy Collective",
     "icon": "dating-privacy-collective.svg",

--- a/manifests/experiences/twitter/__tests__/database.test.js
+++ b/manifests/experiences/twitter/__tests__/database.test.js
@@ -16,13 +16,7 @@ function runQuery(sqlFilePath) {
 }
 
 beforeAll(async () => {
-  const fileManager = new FileManager(
-    {
-      'data/ad-impressions.js': preprocessors.twitter,
-      'data/ad-engagements.js': preprocessors.twitter
-    },
-    true
-  )
+  const fileManager = new FileManager(preprocessors.twitter, true)
   const fileImpressions = mockFile(
     'data/ad-impressions.js',
     JSON.stringify(adImpressions)

--- a/manifests/experiences/twitter/twitter.json
+++ b/manifests/experiences/twitter/twitter.json
@@ -5,11 +5,7 @@
   "ext": "zip",
   "data": ["twitter.zip", "twitter-sample.zip"],
   "files": ["data/ad-impressions.js", "data/ad-engagements.js"],
-  "preprocessors": {
-    "data/ad-impressions.js": "twitter",
-    "data/ad-engagements.js": "twitter",
-    "data/personalization.js": "twitter"
-  },
+  "preprocessor": "twitter",
   "collaborator": {
     "title": "The Eyeballs Collective",
     "icon": "the-eyeballs.svg",

--- a/manifests/index.js
+++ b/manifests/index.js
@@ -71,7 +71,7 @@ const manifests = Object.fromEntries(
       isGenericViewer,
       url,
       showDataExplorer,
-      preprocessors = {},
+      preprocessor,
       timedObservationsViewer = {},
       defaultView = [],
       ...rest
@@ -104,17 +104,10 @@ const manifests = Object.fromEntries(
         throw new Error(`[${dir}] parameter ext is invalid`)
       }
     }
-    Object.values(preprocessors).forEach(preprocessor => {
-      if (!(preprocessor in allPreprocessors)) {
-        throw new Error(`[${dir}] Preprocessor ${preprocessor} does not exist`)
-      }
-    })
-    const preprocessorFuncs = Object.fromEntries(
-      Object.entries(preprocessors).map(([filename, preprocessorName]) => [
-        filename,
-        allPreprocessors[preprocessorName]
-      ])
-    )
+    if (preprocessor && !(preprocessor in allPreprocessors)) {
+      throw new Error(`[${dir}] Preprocessor ${preprocessor} does not exist`)
+    }
+    const preprocessorFunc = allPreprocessors[preprocessor]
 
     if (isGenericViewer && !showDataExplorer) {
       throw new Error('the explorer experience must show the data explorer')
@@ -160,7 +153,7 @@ const manifests = Object.fromEntries(
         files,
         multiple,
         data,
-        preprocessors: preprocessorFuncs,
+        preprocessor: preprocessorFunc,
         collaborator,
         isGenericViewer,
         url,

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -196,7 +196,7 @@ export default {
           (r, i) => new File([blobs[i]], r.name.substr(6))
         )
         this.fileManager = new FileManager(
-          this.manifest.preprocessors,
+          this.manifest.preprocessor,
           false,
           fileManagerWorkers
         )

--- a/utils/__mocks__/file-manager-mock.js
+++ b/utils/__mocks__/file-manager-mock.js
@@ -6,7 +6,7 @@ export function mockFile(fileName, content) {
 }
 
 export async function mockFileManager(fileName, content) {
-  const fileManager = new FileManager({}, true)
+  const fileManager = new FileManager(null, true)
   const file = mockFile(fileName, content)
   await fileManager.init([file], true)
   return fileManager

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -9,7 +9,7 @@ test('an empty file manager', async () => {
 })
 
 test('a json file in file manager', async () => {
-  const fileManager = new FileManager({}, true)
+  const fileManager = new FileManager(null, true)
   const fileName = 'bibi/bobo.json'
   const file = mockFile(fileName, '{"hello": 1}')
   await fileManager.init([file], true)
@@ -20,7 +20,7 @@ test('a json file in file manager', async () => {
 })
 
 test('findMatchingObjects', async () => {
-  const fileManager = new FileManager({}, true)
+  const fileManager = new FileManager(null, true)
   const fileName = 'bibi/bubo.json'
   const fileContent = '{"hello": [11,22,33]}'
   const file = mockFile(fileName, fileContent)
@@ -41,7 +41,7 @@ test('findMatchingObjects', async () => {
 })
 
 test('short filenames', async () => {
-  const fileManager = new FileManager({}, true)
+  const fileManager = new FileManager(null, true)
   const f1 = 'foo/bar.txt'
   const f2 = 'foo/toc.txt'
   const f3 = 'bar.txt'


### PR DESCRIPTION
Following the discussion in #374, the Facebook preprocessor needs to be applied on all files, even those that are not listed in the manifest