### PR TITLE
feat: put summary in a dedicated tab. clicking files opens explorer

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -49,6 +49,7 @@
             centered
             fixed-tabs
           >
+            <VTab>Summary</VTab>
             <VTab>Files</VTab>
             <VTab v-for="(el, index) in defaultView" :key="index">
               {{ el.title }}
@@ -56,6 +57,9 @@
             <VTab v-if="consentForm">Share my data</VTab>
           </VTabs>
           <VTabsItems v-model="tab">
+            <VTabItem>
+              <UnitSummary v-bind="{ fileManager }" />
+            </VTabItem>
             <VTabItem>
               <UnitFileExplorer v-bind="{ fileManager }" />
             </VTabItem>
@@ -103,9 +107,11 @@ import FileManager from '~/utils/file-manager'
 import fileManagerWorkers from '~/utils/file-manager-workers'
 import parseYarrrml from '~/utils/parse-yarrrml'
 import rdfUtils from '~/utils/rdf'
+import UnitSummary from '~/components/unit/UnitSummary'
 
 export default {
   name: 'TheDataExperience',
+  components: { UnitSummary },
   props: {
     title: {
       type: String,
@@ -232,6 +238,11 @@ export default {
             .split(',')
             .map(ext => `.${ext}`)
     }
+  },
+  mounted() {
+    this.$root.$on('setFile', filename => {
+      this.tab = 1
+    })
   },
   methods: {
     handleError(error) {

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -107,11 +107,9 @@ import FileManager from '~/utils/file-manager'
 import fileManagerWorkers from '~/utils/file-manager-workers'
 import parseYarrrml from '~/utils/parse-yarrrml'
 import rdfUtils from '~/utils/rdf'
-import UnitSummary from '~/components/unit/UnitSummary'
 
 export default {
   name: 'TheDataExperience',
-  components: { UnitSummary },
   props: {
     title: {
       type: String,
@@ -240,7 +238,7 @@ export default {
     }
   },
   mounted() {
-    this.$root.$on('setFile', filename => {
+    this.$root.$on('goToFileExplorer', () => {
       this.tab = 1
     })
   },

--- a/components/unit/UnitSummary.vue
+++ b/components/unit/UnitSummary.vue
@@ -10,7 +10,8 @@
         }}</b
         >)
         <template v-if="nDataPoints">
-          and found <b>{{ nDataPoints.toLocaleString() }}</b> datapoints
+          and found <b>{{ nDataPoints.toLocaleString() }}</b>
+          {{ plurify('datapoint') }}
         </template>
         :
         <ul v-if="filesInformation">
@@ -21,9 +22,11 @@
             <!-- eslint-disable-next-line vue/no-v-html -->
             <span v-html="globalDescription"></span>
             <span v-for="({ filename, description }, j) in topFiles" :key="j">
-              <BaseButton @click="$root.$emit('setFile', filename)">
-                {{ fileManager.getShortFilename(filename) }}
-              </BaseButton>
+              <u>
+                <a @click="onFileClick(filename)">
+                  {{ fileManager.getShortFilename(filename) }}
+                </a>
+              </u>
               <span>{{ description }}</span>
             </span>
           </li>
@@ -36,11 +39,9 @@
 import _ from 'lodash'
 import FileManager from '~/utils/file-manager'
 import { humanReadableFileSize, plurify } from '~/manifests/utils'
-import BaseButton from '~/components/base/button/BaseButton'
 
 export default {
   name: 'UnitSummary',
-  components: { BaseButton },
   props: {
     fileManager: {
       type: FileManager,
@@ -112,6 +113,10 @@ export default {
   },
   methods: {
     plurify,
+    onFileClick(filename) {
+      this.$store.commit('setFileExplorerCurrentFile', filename)
+      this.$root.$emit('goToFileExplorer')
+    },
     async setNumberOfDataPoints() {
       this.nDataPoints = _.sum(
         await Promise.all(

--- a/components/unit/UnitSummary.vue
+++ b/components/unit/UnitSummary.vue
@@ -114,7 +114,7 @@ export default {
   methods: {
     plurify,
     onFileClick(filename) {
-      this.$store.commit('setFileExplorerCurrentFile', filename)
+      this.$store.commit('setFileExplorerCurrentItem', { filename })
       this.$root.$emit('goToFileExplorer')
     },
     async setNumberOfDataPoints() {

--- a/components/unit/UnitSummary.vue
+++ b/components/unit/UnitSummary.vue
@@ -1,0 +1,180 @@
+<template>
+  <div>
+    <VCard>
+      <VCardTitle class="justify-center">
+        Here's a summary of what we have found
+      </VCardTitle>
+      <VCardText>
+        Analysed <b>{{ nFiles }}</b> {{ plurify('file', nFiles) }} (<b>{{
+          dataSizeString
+        }}</b
+        >)
+        <template v-if="nDataPoints">
+          and found <b>{{ nDataPoints.toLocaleString() }}</b> datapoints
+        </template>
+        :
+        <ul v-if="filesInformation">
+          <li
+            v-for="({ globalDescription, topFiles }, i) in filesInformation"
+            :key="i"
+          >
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="globalDescription"></span>
+            <span v-for="({ filename, description }, j) in topFiles" :key="j">
+              <BaseButton @click="$root.$emit('setFile', filename)">
+                {{ fileManager.getShortFilename(filename) }}
+              </BaseButton>
+              <span>{{ description }}</span>
+            </span>
+          </li>
+        </ul>
+      </VCardText>
+    </VCard>
+  </div>
+</template>
+<script>
+import _ from 'lodash'
+import FileManager from '~/utils/file-manager'
+import { humanReadableFileSize, plurify } from '~/manifests/utils'
+import BaseButton from '~/components/base/button/BaseButton'
+
+export default {
+  name: 'UnitSummary',
+  components: { BaseButton },
+  props: {
+    fileManager: {
+      type: FileManager,
+      required: true
+    }
+  },
+  data() {
+    return {
+      group2ext: {
+        'audio file': ['mp3', 'm4a', 'wav', 'aac', 'webp'],
+        'image file': ['jpg', 'jpeg', 'png', 'gif', 'bnp'],
+        'video file': ['avi', 'mov', 'mp4', 'mpg'],
+        document: ['pdf', 'html', 'doc', 'docx', 'rtf', 'odt'],
+        spreadsheet: ['xls', 'xlsx', 'ods'],
+        'archive file': ['zip', '7z', 'rar', 'gz'],
+        'data file': ['json', 'csv', 'tsv', 'xml'],
+        'text file': ['txt', 'md'],
+        other: []
+      },
+      computeNPoints: false,
+      nDataPoints: null,
+      filesInformation: []
+    }
+  },
+  computed: {
+    ext2group() {
+      return Object.fromEntries(
+        Object.entries(this.group2ext).flatMap(entry =>
+          entry[1].map(ext => [ext, entry[0]])
+        )
+      )
+    },
+    nFiles() {
+      return this.fileManager.fileList.length
+    },
+    totalSize() {
+      return _.sumBy(this.fileManager.fileList, f => f.size)
+    },
+    dataSizeString() {
+      return humanReadableFileSize(this.totalSize)
+    },
+    fileExts() {
+      return this.fileManager.fileList
+        .map(f => f.name.match(/^.+\.(.+?)$/)?.[1])
+        .filter(m => !_.isUndefined(m))
+    },
+    sortedGroupCounts() {
+      const groups = this.fileExts.map(ext => this.ext2group[ext])
+      const occurrences = _.mapValues(
+        _.groupBy(groups, _.identity),
+        v => v.length
+      )
+      return _.sortBy(Object.entries(occurrences), ([group, count]) =>
+        group === 'other' ? 1 : -count
+      )
+    }
+  },
+  watch: {
+    fileManager: {
+      immediate: true,
+      handler() {
+        this.completeGroupsTable()
+        this.setExtensionTexts()
+        if (this.computeNPoints) {
+          this.setNumberOfDataPoints()
+        }
+      }
+    }
+  },
+  methods: {
+    plurify,
+    async setNumberOfDataPoints() {
+      this.nDataPoints = _.sum(
+        await Promise.all(
+          this.fileManager
+            .getFilenames()
+            .map(async f => await this.fileManager.getNumberOfDataPoints(f))
+        )
+      )
+    },
+    completeGroupsTable() {
+      // Add unknown extensions to the 'other' group
+      for (const ext of this.fileExts) {
+        if (!(ext in this.ext2group) && !this.group2ext.other.includes(ext)) {
+          this.group2ext.other.push(ext)
+        }
+      }
+    },
+    async setExtensionTexts() {
+      const showAtMost = 3
+      const pointsPerFile = await Promise.all(
+        this.fileManager
+          .getFilenames()
+          .map(async f => [
+            f,
+            this.computeNPoints
+              ? await this.fileManager.getNumberOfDataPoints(f)
+              : 0
+          ])
+      )
+      this.filesInformation = this.sortedGroupCounts.map(([group, c]) => {
+        const re = new RegExp(`.+\\.${this.group2ext[group].join('|')}$`)
+        const filterFunc = ([f, _n]) => re.test(f)
+        const files = pointsPerFile.filter(filterFunc)
+        const shownFiles = _.take(
+          _.sortBy(files, ([_f, n]) => -n),
+          showAtMost
+        )
+        const nPointsGroup = _.sumBy(files, ([_f, n]) => n)
+        const topFiles = shownFiles.map(([f, nPoints]) => ({
+          filename: f,
+          description: `${
+            nPoints === 0
+              ? ''
+              : ` (${nPoints.toLocaleString()} ${plurify(
+                  group === 'text file' ? 'line' : 'datapoint',
+                  nPoints
+                )})`
+          }`
+        }))
+        const globalDescription = `<b>${c} ${plurify(
+          group === 'other' ? 'other file' : group,
+          c
+        )}</b>${
+          nPointsGroup > 0
+            ? ` (${nPointsGroup.toLocaleString()} ${plurify(
+                group === 'text file' ? 'line' : 'datapoint',
+                nPointsGroup
+              )})`
+            : ''
+        }${files.length > showAtMost ? ' including: ' : ':'}`
+        return { topFiles, globalDescription }
+      })
+    }
+  }
+}
+</script>

--- a/components/unit/UnitSummary.vue
+++ b/components/unit/UnitSummary.vue
@@ -22,12 +22,10 @@
             <!-- eslint-disable-next-line vue/no-v-html -->
             <span v-html="globalDescription"></span>
             <span v-for="({ filename, description }, j) in topFiles" :key="j">
-              <u>
-                <a @click="onFileClick(filename)">
-                  {{ fileManager.getShortFilename(filename) }}
-                </a>
-              </u>
-              <span>{{ description }}</span>
+              <a @click="onFileClick(filename)"
+                ><u>{{ fileManager.getShortFilename(filename) }}</u></a
+              ><span>{{ description }}</span
+              ><span v-if="j < topFiles.length - 1">, </span>
             </span>
           </li>
         </ul>

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -68,7 +68,6 @@
             :search="search"
             :items="treeItems"
             :active.sync="active"
-            @update:active="onUpdateActive"
           >
             <template #prepend="{ item }">
               <VIcon>
@@ -152,8 +151,17 @@ export default {
       get() {
         return this.selectedItem ? [this.selectedItem] : []
       },
-      set(value) {
-        this.$store.commit('setFileExplorerCurrentFile', value.filename)
+      set([item]) {
+        // item might be undefined (when unselecting)
+        if (item) {
+          // close drawer when file is selected
+          this.mini = true
+          if (!this.containers.has(item?.type)) {
+            this.$store.commit('setFileExplorerCurrentFile', item.filename)
+          }
+        } else {
+          this.$store.commit('setFileExplorerCurrentFile', null)
+        }
       }
     },
     selectedItem() {
@@ -252,18 +260,6 @@ export default {
         }
       }
       return findItem(this.treeItems)
-    },
-    onUpdateActive([item]) {
-      // item might be undefined (when unselecting)
-      if (item) {
-        // close drawer when file is selected
-        this.mini = true
-        if (!this.containers.has(item?.type)) {
-          this.$store.commit('setFileExplorerCurrentFile', item.filename)
-        }
-      } else {
-        this.$store.commit('setFileExplorerCurrentFile', null)
-      }
     }
   }
 }

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -113,6 +113,7 @@
 </template>
 
 <script>
+import _ from 'lodash'
 import FileManager from '~/utils/file-manager.js'
 import { makeTableData } from '~/manifests/generic-pipelines'
 
@@ -149,24 +150,29 @@ export default {
   computed: {
     active: {
       get() {
-        return this.selectedItem ? [this.selectedItem] : []
+        return _.has(this.selectedItem, 'filename') ? [this.selectedItem] : []
       },
       set([item]) {
         // item might be undefined (when unselecting)
         if (item) {
           // close drawer when file is selected
           this.mini = true
-          if (!this.containers.has(item?.type)) {
-            this.$store.commit('setFileExplorerCurrentFile', item.filename)
+          if (!this.containers.has(item.type)) {
+            this.$store.commit('setFileExplorerCurrentItem', item)
           }
         } else {
-          this.$store.commit('setFileExplorerCurrentFile', null)
+          this.$store.commit('setFileExplorerCurrentItem', {})
         }
       }
     },
     selectedItem() {
-      if (this.filename) {
-        return this.searchItemWithFilename(this.filename)
+      const item = this.$store.getters.fileExplorerCurrentItem
+      if (_.has(item, 'filename')) {
+        if (!_.has(item, 'type')) {
+          return this.searchItemWithFilename(item.filename)
+        } else {
+          return item
+        }
       } else {
         return {}
       }
@@ -176,7 +182,7 @@ export default {
       return this.selectedItem?.type
     },
     filename() {
-      return this.$store.getters.fileExplorerCurrentFile
+      return this.selectedItem.filename
     },
     treeItems() {
       return this.fileManager.getTreeItems()

--- a/store/index.js
+++ b/store/index.js
@@ -15,7 +15,7 @@ export const state = () => ({
       )
     ])
   ),
-  fileExplorerCurrentFile: null
+  fileExplorerCurrentItem: {}
 })
 
 export const getters = {
@@ -48,8 +48,8 @@ export const getters = {
     ({ params: { key } }) => {
       return state.manifestMap[key] || {}
     },
-  fileExplorerCurrentFile(state) {
-    return state.fileExplorerCurrentFile
+  fileExplorerCurrentItem(state) {
+    return state.fileExplorerCurrentItem
   }
 }
 
@@ -60,7 +60,7 @@ export const mutations = {
   setResult(state, { company, experience, result }) {
     state.results[company][experience] = result
   },
-  setFileExplorerCurrentFile(state, filename) {
-    state.fileExplorerCurrentFile = filename
+  setFileExplorerCurrentItem(state, item) {
+    state.fileExplorerCurrentItem = item
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -14,7 +14,8 @@ export const state = () => ({
         manifestMap[k].defaultView?.map(b => [b.key, null]) ?? []
       )
     ])
-  )
+  ),
+  fileExplorerCurrentFile: null
 })
 
 export const getters = {
@@ -46,7 +47,10 @@ export const getters = {
     state =>
     ({ params: { key } }) => {
       return state.manifestMap[key] || {}
-    }
+    },
+  fileExplorerCurrentFile(state) {
+    return state.fileExplorerCurrentFile
+  }
 }
 
 export const mutations = {
@@ -55,5 +59,8 @@ export const mutations = {
   },
   setResult(state, { company, experience, result }) {
     state.results[company][experience] = result
+  },
+  setFileExplorerCurrentFile(state, filename) {
+    state.fileExplorerCurrentFile = filename
   }
 }


### PR DESCRIPTION
Addresses #364 and #466 

Changes:
- moved the summary to a dedicated tab (the first one)
- clicking a file in the summary brings you to the file explorer tab with the correct file selected
- moved `FileExplorer`'s selected file to vuex store