### PR TITLE
fix: undefined values in twitter sql

### DIFF
--- a/manifests/experiences/twitter/__tests__/database.test.js
+++ b/manifests/experiences/twitter/__tests__/database.test.js
@@ -2,7 +2,12 @@ import fs from 'fs'
 import path from 'path'
 
 import databaseBuilder from '../database'
-import { adImpressions, adEngagements } from './samples.helpers'
+import {
+  adImpressions,
+  adEngagements,
+  missingAttributesImpressions,
+  missingAttributesEngagements
+} from './samples.helpers'
 import preprocessors from '~/manifests/preprocessors'
 import FileManager from '~/utils/file-manager'
 import { mockFile } from '~/utils/__mocks__/file-manager-mock'
@@ -15,7 +20,7 @@ function runQuery(sqlFilePath) {
   return db.select(sql)
 }
 
-beforeAll(async () => {
+async function getDatabase(adImpressions, adEngagements) {
   const fileManager = new FileManager(
     {
       'data/ad-impressions.js': preprocessors.twitter,
@@ -34,247 +39,316 @@ beforeAll(async () => {
   await fileManager.init([fileImpressions, fileEngagements], true)
 
   db = await databaseBuilder(fileManager)
+}
+
+describe('with incomplete samples', () => {
+  beforeAll(async () => {
+    await getDatabase(
+      missingAttributesImpressions,
+      missingAttributesEngagements
+    )
+  })
+
+  afterAll(() => {
+    db.close()
+  })
+
+  test('the database builder creates the tables correctly', () => {
+    let result, expected
+
+    // Table twitterAds
+    result = db.select('SELECT * FROM twitterAds')
+    expected = {
+      headers: ['id', 'tweetId', 'advertiserName', 'time', 'engagement'],
+      items: [
+        {
+          id: 0,
+          tweetId: null,
+          advertiserName: null,
+          time: null,
+          engagement: 0
+        },
+        {
+          id: 1,
+          tweetId: null,
+          advertiserName: null,
+          time: null,
+          engagement: 1
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+
+    // Table twitterCriteria
+    result = db.select('SELECT * FROM twitterCriteria')
+    expected = {
+      headers: ['id', 'adId', 'targetingType', 'targetingValue'],
+      items: [
+        {
+          id: 0,
+          adId: 0,
+          targetingType: null,
+          targetingValue: null
+        },
+        {
+          id: 1,
+          adId: 1,
+          targetingType: null,
+          targetingValue: null
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
 })
 
-afterAll(() => {
-  db.close()
-})
+describe('with complete samples', () => {
+  beforeAll(async () => {
+    await getDatabase(adImpressions, adEngagements)
+  })
 
-test('the database builder creates the tables correctly', () => {
-  let result, expected
+  afterAll(() => {
+    db.close()
+  })
 
-  // Table twitterAds
-  result = db.select('SELECT * FROM twitterAds')
-  expected = {
-    headers: ['id', 'tweetId', 'advertiserName', 'time', 'engagement'],
-    items: [
-      {
-        id: 0,
-        tweetId: '1369584490276741122',
-        advertiserName: 'Illumeably',
-        time: '2021-04-15 19:51:50',
-        engagement: 0
-      },
-      {
-        id: 1,
-        tweetId: '1381646278988292098',
-        advertiserName: 'PwC Switzerland',
-        time: '2021-04-15 19:43:20',
-        engagement: 1
-      }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
+  test('the database builder creates the tables correctly', () => {
+    let result, expected
 
-  // Table twitterCriteria
-  result = db.select('SELECT * FROM twitterCriteria')
-  expected = {
-    headers: ['id', 'adId', 'targetingType', 'targetingValue'],
-    items: [
-      {
-        id: 0,
-        adId: 0,
-        targetingType: 'Platforms',
-        targetingValue: 'Desktop'
-      },
-      {
-        id: 1,
-        adId: 0,
-        targetingType: 'Languages',
-        targetingValue: 'English'
-      },
-      {
-        id: 2,
-        adId: 1,
-        targetingType: 'Locations',
-        targetingValue: 'Switzerland'
-      },
-      {
-        id: 3,
-        adId: 1,
-        targetingType: 'Age',
-        targetingValue: '35 and up'
-      }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
-})
+    // Table twitterAds
+    result = db.select('SELECT * FROM twitterAds')
+    expected = {
+      headers: ['id', 'tweetId', 'advertiserName', 'time', 'engagement'],
+      items: [
+        {
+          id: 0,
+          tweetId: '1369584490276741122',
+          advertiserName: 'Illumeably',
+          time: '2021-04-15 19:51:50',
+          engagement: 0
+        },
+        {
+          id: 1,
+          tweetId: '1381646278988292098',
+          advertiserName: 'PwC Switzerland',
+          time: '2021-04-15 19:43:20',
+          engagement: 1
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
 
-test('query advertisers-per-day returns the correct items', () => {
-  const result = runQuery('../queries/advertisers-per-day.sql')
-  const expected = {
-    headers: ['advertiserName', 'date', 'count'],
-    items: [
-      { advertiserName: 'Illumeably', date: '2021-04-15', count: 1 },
-      { advertiserName: 'PwC Switzerland', date: '2021-04-15', count: 1 }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
-})
+    // Table twitterCriteria
+    result = db.select('SELECT * FROM twitterCriteria')
+    expected = {
+      headers: ['id', 'adId', 'targetingType', 'targetingValue'],
+      items: [
+        {
+          id: 0,
+          adId: 0,
+          targetingType: 'Platforms',
+          targetingValue: 'Desktop'
+        },
+        {
+          id: 1,
+          adId: 0,
+          targetingType: 'Languages',
+          targetingValue: 'English'
+        },
+        {
+          id: 2,
+          adId: 1,
+          targetingType: 'Locations',
+          targetingValue: 'Switzerland'
+        },
+        {
+          id: 3,
+          adId: 1,
+          targetingType: 'Age',
+          targetingValue: '35 and up'
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
 
-test('query all-advertisers returns the correct items', () => {
-  const result = runQuery('../queries/all-advertisers.sql')
-  const expected = {
-    headers: ['advertiserName', 'count'],
-    items: [
-      { advertiserName: 'Illumeably', count: 1 },
-      { advertiserName: 'PwC Switzerland', count: 1 }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
-})
+  test('query advertisers-per-day returns the correct items', () => {
+    const result = runQuery('../queries/advertisers-per-day.sql')
+    const expected = {
+      headers: ['advertiserName', 'date', 'count'],
+      items: [
+        { advertiserName: 'Illumeably', date: '2021-04-15', count: 1 },
+        { advertiserName: 'PwC Switzerland', date: '2021-04-15', count: 1 }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
 
-test('query all-criteria-all-advertisers returns the correct items', () => {
-  const result = runQuery('../queries/all-criteria-all-advertisers.sql')
-  const expected = {
-    headers: ['advertiserName', 'targetingType', 'targetingValue', 'count'],
-    items: [
-      {
-        advertiserName: 'Illumeably',
-        targetingType: 'Platforms',
-        targetingValue: 'Desktop',
-        count: 1
-      },
-      {
-        advertiserName: 'Illumeably',
-        targetingType: 'Languages',
-        targetingValue: 'English',
-        count: 1
-      },
-      {
-        advertiserName: 'PwC Switzerland',
-        targetingType: 'Locations',
-        targetingValue: 'Switzerland',
-        count: 1
-      },
-      {
-        advertiserName: 'PwC Switzerland',
-        targetingType: 'Age',
-        targetingValue: '35 and up',
-        count: 1
-      }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
-})
+  test('query all-advertisers returns the correct items', () => {
+    const result = runQuery('../queries/all-advertisers.sql')
+    const expected = {
+      headers: ['advertiserName', 'count'],
+      items: [
+        { advertiserName: 'Illumeably', count: 1 },
+        { advertiserName: 'PwC Switzerland', count: 1 }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
 
-test('query overview returns the correct items', () => {
-  const result = runQuery('../queries/overview.sql')
-  const expected = {
-    headers: [
-      'tweetId',
-      'companyName',
-      'engagement',
-      'date',
-      'targetingType',
-      'targetingValue'
-    ],
-    items: [
-      {
-        tweetId: '1369584490276741122',
-        companyName: 'Illumeably',
-        engagement: 0,
-        date: '2021-04-15 19:51:50',
-        targetingType: 'Platforms',
-        targetingValue: 'Desktop'
-      },
-      {
-        tweetId: '1369584490276741122',
-        companyName: 'Illumeably',
-        engagement: 0,
-        date: '2021-04-15 19:51:50',
-        targetingType: 'Languages',
-        targetingValue: 'English'
-      },
-      {
-        tweetId: '1381646278988292098',
-        companyName: 'PwC Switzerland',
-        engagement: 1,
-        date: '2021-04-15 19:43:20',
-        targetingType: 'Locations',
-        targetingValue: 'Switzerland'
-      },
-      {
-        tweetId: '1381646278988292098',
-        companyName: 'PwC Switzerland',
-        engagement: 1,
-        date: '2021-04-15 19:43:20',
-        targetingType: 'Age',
-        targetingValue: '35 and up'
-      }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
-})
+  test('query all-criteria-all-advertisers returns the correct items', () => {
+    const result = runQuery('../queries/all-criteria-all-advertisers.sql')
+    const expected = {
+      headers: ['advertiserName', 'targetingType', 'targetingValue', 'count'],
+      items: [
+        {
+          advertiserName: 'Illumeably',
+          targetingType: 'Platforms',
+          targetingValue: 'Desktop',
+          count: 1
+        },
+        {
+          advertiserName: 'Illumeably',
+          targetingType: 'Languages',
+          targetingValue: 'English',
+          count: 1
+        },
+        {
+          advertiserName: 'PwC Switzerland',
+          targetingType: 'Locations',
+          targetingValue: 'Switzerland',
+          count: 1
+        },
+        {
+          advertiserName: 'PwC Switzerland',
+          targetingType: 'Age',
+          targetingValue: '35 and up',
+          count: 1
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
 
-test('query targeting-criteria-all-advertisers returns the correct items', () => {
-  const result = runQuery('../queries/targeting-criteria-all-advertisers.sql')
-  const expected = {
-    headers: ['targetingType', 'targetingValue', 'count'],
-    items: [
-      {
-        targetingType: 'Platforms',
-        targetingValue: 'Desktop',
-        count: 1
-      },
-      {
-        targetingType: 'Languages',
-        targetingValue: 'English',
-        count: 1
-      },
-      {
-        targetingType: 'Locations',
-        targetingValue: 'Switzerland',
-        count: 1
-      },
-      {
-        targetingType: 'Age',
-        targetingValue: '35 and up',
-        count: 1
-      }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
-})
+  test('query overview returns the correct items', () => {
+    const result = runQuery('../queries/overview.sql')
+    const expected = {
+      headers: [
+        'tweetId',
+        'companyName',
+        'engagement',
+        'date',
+        'targetingType',
+        'targetingValue'
+      ],
+      items: [
+        {
+          tweetId: '1369584490276741122',
+          companyName: 'Illumeably',
+          engagement: 0,
+          date: '2021-04-15 19:51:50',
+          targetingType: 'Platforms',
+          targetingValue: 'Desktop'
+        },
+        {
+          tweetId: '1369584490276741122',
+          companyName: 'Illumeably',
+          engagement: 0,
+          date: '2021-04-15 19:51:50',
+          targetingType: 'Languages',
+          targetingValue: 'English'
+        },
+        {
+          tweetId: '1381646278988292098',
+          companyName: 'PwC Switzerland',
+          engagement: 1,
+          date: '2021-04-15 19:43:20',
+          targetingType: 'Locations',
+          targetingValue: 'Switzerland'
+        },
+        {
+          tweetId: '1381646278988292098',
+          companyName: 'PwC Switzerland',
+          engagement: 1,
+          date: '2021-04-15 19:43:20',
+          targetingType: 'Age',
+          targetingValue: '35 and up'
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
 
-test('query targeting-criteria-by-advertiser returns the correct items', () => {
-  const result = runQuery('../queries/targeting-criteria-by-advertiser.sql')
-  const expected = {
-    headers: ['advertiserName', 'targetingType', 'targetingValue', 'count'],
-    items: [
-      {
-        advertiserName: 'Illumeably',
-        targetingType: 'Platforms',
-        targetingValue: 'Desktop',
-        count: 1
-      },
-      {
-        advertiserName: 'Illumeably',
-        targetingType: 'Languages',
-        targetingValue: 'English',
-        count: 1
-      },
-      {
-        advertiserName: 'PwC Switzerland',
-        targetingType: 'Locations',
-        targetingValue: 'Switzerland',
-        count: 1
-      },
-      {
-        advertiserName: 'PwC Switzerland',
-        targetingType: 'Age',
-        targetingValue: '35 and up',
-        count: 1
-      }
-    ]
-  }
-  arrayEqualNoOrder(result.headers, expected.headers)
-  arrayEqualNoOrder(result.items, expected.items)
+  test('query targeting-criteria-all-advertisers returns the correct items', () => {
+    const result = runQuery('../queries/targeting-criteria-all-advertisers.sql')
+    const expected = {
+      headers: ['targetingType', 'targetingValue', 'count'],
+      items: [
+        {
+          targetingType: 'Platforms',
+          targetingValue: 'Desktop',
+          count: 1
+        },
+        {
+          targetingType: 'Languages',
+          targetingValue: 'English',
+          count: 1
+        },
+        {
+          targetingType: 'Locations',
+          targetingValue: 'Switzerland',
+          count: 1
+        },
+        {
+          targetingType: 'Age',
+          targetingValue: '35 and up',
+          count: 1
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
+
+  test('query targeting-criteria-by-advertiser returns the correct items', () => {
+    const result = runQuery('../queries/targeting-criteria-by-advertiser.sql')
+    const expected = {
+      headers: ['advertiserName', 'targetingType', 'targetingValue', 'count'],
+      items: [
+        {
+          advertiserName: 'Illumeably',
+          targetingType: 'Platforms',
+          targetingValue: 'Desktop',
+          count: 1
+        },
+        {
+          advertiserName: 'Illumeably',
+          targetingType: 'Languages',
+          targetingValue: 'English',
+          count: 1
+        },
+        {
+          advertiserName: 'PwC Switzerland',
+          targetingType: 'Locations',
+          targetingValue: 'Switzerland',
+          count: 1
+        },
+        {
+          advertiserName: 'PwC Switzerland',
+          targetingType: 'Age',
+          targetingValue: '35 and up',
+          count: 1
+        }
+      ]
+    }
+    arrayEqualNoOrder(result.headers, expected.headers)
+    arrayEqualNoOrder(result.items, expected.items)
+  })
 })

--- a/manifests/experiences/twitter/__tests__/samples.helpers.js
+++ b/manifests/experiences/twitter/__tests__/samples.helpers.js
@@ -87,3 +87,38 @@ export const adEngagements = [
     }
   }
 ]
+
+export const missingAttributesImpressions = [
+  {
+    ad: {
+      adsUserData: {
+        adImpressions: {
+          impressions: [
+            {
+              matchedTargetingCriteria: [{}]
+            }
+          ]
+        }
+      }
+    }
+  }
+]
+
+export const missingAttributesEngagements = [
+  {
+    ad: {
+      adsUserData: {
+        adEngagements: {
+          engagements: [
+            {
+              impressionAttributes: {
+                matchedTargetingCriteria: [{}]
+              },
+              engagementAttributes: [{}]
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/manifests/experiences/twitter/database.js
+++ b/manifests/experiences/twitter/database.js
@@ -44,15 +44,13 @@ export default async function databaseBuilder(fileManager) {
   ]
   for (const file of files) {
     file.values.forEach(v => {
-      const tweetId = v.promotedTweetInfo ? v.promotedTweetInfo.tweetId : null
-      const advertiserName = v.advertiserInfo
-        ? v.advertiserInfo.advertiserName
-        : null
+      const tweetId = v.promotedTweetInfo?.tweetId ?? null
+      const advertiserName = v.advertiserInfo?.advertiserName ?? null
       adsItems.push({
         id: adsId,
         tweetId,
         advertiserName,
-        time: v.impressionTime,
+        time: v.impressionTime ?? null,
         engagement: file.engagement
       })
       const criteria = JSONPath({

--- a/utils/sql.js
+++ b/utils/sql.js
@@ -102,6 +102,7 @@ export class DB {
 
   /**
    * Insert all the given items in the database.
+   * IMPORTANT: the items should NOT contain any 'undefined' value. Use null instead.
    * @param {String} table the table in which we insert the values.
    * @param {Array<Object>} items an array of rows to insert. Each row should contain the same attributes.
    */


### PR DESCRIPTION
Some users have data with ads that don't have an `impressionTime`. This was causing an error when inserting the values into the database, because we didn't properly replace `undefined` values with `null`

I've fixed the bug and added a new test that checks for these cases.