### PR TITLE
refactor: rewrite itemifyJSON

### DIFF
--- a/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
+++ b/components/unit/file-explorer/viewer/UnitFileExplorerViewerJson.vue
@@ -91,11 +91,11 @@ export default {
     },
     iconForNode(type) {
       switch (type) {
-        case nodeTypes.tree:
+        case nodeTypes.TREE:
           return mdiCodeJson
-        case nodeTypes.list:
+        case nodeTypes.LIST:
           return mdiFormatListBulletedSquare
-        case nodeTypes.leaf:
+        case nodeTypes.LEAF:
           return mdiInformationOutline
       }
     },

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -13,7 +13,7 @@ import {
 } from '@mdi/js'
 import _ from 'lodash'
 import { matchNormalized, findMatchesInContent } from './accessor'
-import itemifyJSON, { nJsonPoints } from '~/utils/json'
+import { itemifyJSON, nJsonPoints } from '~/utils/json'
 import getCsvHeadersAndItems from '~/utils/csv'
 import { runWorker } from '@/utils/utils'
 

--- a/utils/json.js
+++ b/utils/json.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-function filterCondition(item, filter) {
+export function filterCondition(item, filter) {
   filter = filter.toLowerCase()
   return (
     (item.name && `${item.name}`.toLowerCase().includes(filter)) ||
@@ -8,19 +8,43 @@ function filterCondition(item, filter) {
   )
 }
 
-export const nodeTypes = { tree: 'tree', list: 'list', leaf: 'leaf' }
+export const nodeTypes = { TREE: 'tree', LIST: 'list', LEAF: 'leaf' }
+const { TREE, LIST, LEAF } = nodeTypes
+
+export function minifyList(list, path, base = 0) {
+  const groupsPerLevel = 10
+  if (list.length <= groupsPerLevel) return list
+  const groupSize = Math.pow(
+    groupsPerLevel,
+    Math.floor(Math.log(list.length - 1) / Math.log(groupsPerLevel))
+  )
+  return _.chunk(list, groupSize).map((group, i) => {
+    const from = base + groupSize * i + 1
+    const to = base + groupSize * i + group.length
+    return {
+      id: `${path.join('.')}[${from - 1}:${to}]`,
+      name: `[elements ${from} - ${to}]`,
+      path,
+      children: minifyList(group, path, base + i * groupSize),
+      type: nodeTypes.LIST
+    }
+  })
+}
 
 /**
- * itemifyJSON transforms some JSON into a tree, suitable for a Vuetify VTreeview component.
+ * This has been replaced by itemifyJSON.
+ * TODO: delete this when we're sure itemifyJSON does the job
+ * itemifyJSONOld transforms some JSON into a tree, suitable for a Vuetify VTreeview component.
  * @param {String} jsonText
- * @param {Function} filterCondition (optional) a function taking a leaf node as argument
- * and returning true if the node satifisfies the desired filter condition
+ * @param {String} filterString (optional) a string that needs to be contained
+ * in the name or the value of a node for it to match
  * @returns {Array} the tree
  */
-export default function itemifyJSON(jsonText, filter) {
-  const groupsPerLevel = 10
+export function itemifyJSONOld(jsonText, filter) {
   let id = 0
-  function minifyList(list, path, base = 0) {
+  const groupsPerLevel = 10
+  // can't use the common function because it closes over id
+  function minifyListOld(list, path, base = 0) {
     if (list.length <= groupsPerLevel) return list
     const groupSize = Math.pow(
       groupsPerLevel,
@@ -32,8 +56,8 @@ export default function itemifyJSON(jsonText, filter) {
         base + groupSize * i + group.length
       }]`,
       path,
-      children: minifyList(group, path, base + i * groupSize),
-      type: nodeTypes.list
+      children: minifyListOld(group, path, base + i * groupSize),
+      type: nodeTypes.LIST
     }))
   }
   function itemifyRec(tree, path) {
@@ -43,7 +67,7 @@ export default function itemifyJSON(jsonText, filter) {
       return {
         id,
         value: tree,
-        type: nodeTypes.leaf,
+        type: nodeTypes.LEAF,
         path
       }
     } else if (Array.isArray(tree)) {
@@ -66,17 +90,17 @@ export default function itemifyJSON(jsonText, filter) {
         id,
         path,
         name: formatArray(children),
-        type: nodeTypes.list
+        type: nodeTypes.LIST
       }
       if (children.length) {
-        arrayItem.children = minifyList(children, path)
+        arrayItem.children = minifyListOld(children, path)
       }
       return arrayItem
     } else if (tree !== null) {
       // Object node
       const children = Object.entries(tree).flatMap(([key, v]) => {
         const inner = itemifyRec(v, [...path, key])
-        const name = _.startCase(key)
+        const name = formatAttributeName(key)
         if (typeof inner.name === 'undefined') {
           // Leaf node (second part)
           const leaf = { ...inner, name }
@@ -96,17 +120,109 @@ export default function itemifyJSON(jsonText, filter) {
         id,
         name: formatObject(tree),
         path,
-        type: nodeTypes.tree
+        type: nodeTypes.TREE
       }
       if (children.length) {
         objectItem.children = children
       }
       return objectItem
     } else {
-      return { id, value: 'null', type: nodeTypes.leaf, path }
+      return { id, value: 'null', type: nodeTypes.LEAF, path }
     }
   }
   return [itemifyRec(JSON.parse(jsonText), [])]
+}
+
+/**
+ * itemifyJSON transforms some JSON into a tree, suitable for a Vuetify VTreeview component.
+ * @param {String} jsonText
+ * @param {String} filterString (optional) a string that needs to be contained
+ * in the name or the value of a node for it to match
+ * @returns {Array} the tree
+ */
+export function itemifyJSON(jsonString, filterString) {
+  const json = JSON.parse(jsonString)
+  const predicate = makePruningPredicateToMatch(filterString)
+  const processAndFilter = (json, path, type, children) => {
+    const item = processJsonNode(json, path, type, children)
+    return predicate(item) ? item : undefined
+  }
+  const found = traverseJson(json, processAndFilter)
+  // We wrap everything in an array for the convenience
+  // of vuetify's tree view
+  return [found || []]
+}
+
+export function traverseJson(json, process, path = []) {
+  if (typeof json !== 'object') {
+    // value (leaf)
+    return process(json, path, LEAF, undefined)
+  } else if (Array.isArray(json)) {
+    // array (list)
+    const processedChildren = json
+      .map((t, i) => traverseJson(t, process, [...path, i]))
+      .filter(ch => ch !== undefined)
+    return process(json, path, LIST, processedChildren)
+  } else if (json !== null) {
+    // object (tree)
+    // The processed children are in a list rather than an object,
+    // because that's more convenient for vuetify's tree view
+    const processedChildren = Object.entries(json)
+      .map(([key, t]) => traverseJson(t, process, [...path, key]))
+      .filter(ch => ch !== undefined)
+    return process(json, path, TREE, processedChildren)
+  } else {
+    // json === null (leaf, I guess)
+    return process(json, path, LEAF, undefined)
+  }
+}
+
+function attributeNameFromPath(path) {
+  const key = path[path.length - 1]
+  return key && isNaN(key) ? key : undefined
+}
+
+export function processJsonNode(json, path, type, processedChildren) {
+  const item = { id: path.join('.'), path, type }
+  const attrName = formatAttributeName(attributeNameFromPath(path))
+  if (type === LEAF) {
+    if (attrName) {
+      item.name = attrName
+    }
+    item.value = json
+  } else if (type === LIST) {
+    const description = formatArray(json)
+    item.name = attrName ? `${attrName} / ${description}` : description
+    if (processedChildren.length > 0) {
+      item.children = minifyList(processedChildren, path)
+    }
+  } else if (type === TREE) {
+    const description = formatObject(json)
+    item.name = attrName ? `${attrName} / ${description}` : description
+    if (processedChildren.length > 0) {
+      // no minifying, objects have few attributes, right?
+      item.children = processedChildren
+    }
+  }
+  return item
+}
+
+export function makePruningPredicateToMatch(filter) {
+  if (!filter) {
+    return () => true
+  }
+  const lowerCaseFilter = filter.toLowerCase()
+  return item => {
+    const name = attributeNameFromPath(item.path)
+    if (name && name.toLowerCase().includes(lowerCaseFilter)) {
+      return true
+    }
+    const value = item.value && '' + item.value
+    if (value && value.toLowerCase().includes(lowerCaseFilter)) {
+      return true
+    }
+    return item.children && item.children.length > 0
+  }
 }
 
 export function formatObject(object) {
@@ -127,6 +243,10 @@ export function formatArray(array) {
   }
   const plural = array.length > 1
   return `[list with ${array.length} item${plural ? 's' : ''}]`
+}
+
+export function formatAttributeName(name) {
+  return _.startCase(name)
 }
 
 export function pathArrayToJsonPath(pathArray) {

--- a/utils/json.test.js
+++ b/utils/json.test.js
@@ -1,52 +1,288 @@
 import { JSONPath } from 'jsonpath-plus'
-import itemifyJSON, { pathArrayToJsonPath, nodeTypes } from '~/utils/json'
+import {
+  itemifyJSONOld,
+  itemifyJSON,
+  traverseJson,
+  processJsonNode,
+  makePruningPredicateToMatch,
+  nodeTypes,
+  pathArrayToJsonPath
+} from '~/utils/json'
 
-const { tree, list, leaf } = nodeTypes
+const { TREE, LIST, LEAF } = nodeTypes
+
+test('traverseJson and processJsonNode and filter', () => {
+  const srcJson = {
+    r: 'roro',
+    a: { n: 'nono', b: [{ c: 1, d: 'dodo' }, 'meuh'] }
+  }
+  const predicate = makePruningPredicateToMatch('dodo')
+  const processAndFilter = (json, path, type, children) => {
+    const item = processJsonNode(json, path, type, children)
+    return predicate(item) ? item : undefined
+  }
+  const processed = traverseJson(srcJson, processAndFilter)
+  const correctProcessed = {
+    id: '',
+    path: [],
+    type: 'tree',
+    name: '{attributes R, A}',
+    children: [
+      {
+        id: 'a',
+        path: ['a'],
+        type: 'tree',
+        name: 'A / {attributes N, B}',
+        children: [
+          {
+            id: 'a.b',
+            path: ['a', 'b'],
+            type: 'list',
+            name: 'B / [list with 2 items]',
+            children: [
+              {
+                id: 'a.b.0',
+                path: ['a', 'b', 0],
+                type: 'tree',
+                name: '{attributes C, D}',
+                children: [
+                  {
+                    id: 'a.b.0.d',
+                    path: ['a', 'b', 0, 'd'],
+                    type: 'leaf',
+                    name: 'D',
+                    value: 'dodo'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  expect(processed).toStrictEqual(correctProcessed)
+  expect(true).toStrictEqual(true)
+})
+
+test('traverseJson and processJsonNode', () => {
+  const srcJson = {
+    r: 'roro',
+    a: { n: 'nono', b: [{ c: 1, d: 'dodo' }, 'meuh'] }
+  }
+  const processed = traverseJson(srcJson, processJsonNode)
+  const correctProcessed = {
+    id: '',
+    path: [],
+    type: 'tree',
+    name: '{attributes R, A}',
+    children: [
+      { id: 'r', path: ['r'], type: 'leaf', name: 'R', value: 'roro' },
+      {
+        id: 'a',
+        path: ['a'],
+        type: 'tree',
+        name: 'A / {attributes N, B}',
+        children: [
+          {
+            id: 'a.n',
+            path: ['a', 'n'],
+            type: 'leaf',
+            name: 'N',
+            value: 'nono'
+          },
+          {
+            id: 'a.b',
+            path: ['a', 'b'],
+            type: 'list',
+            name: 'B / [list with 2 items]',
+            children: [
+              {
+                id: 'a.b.0',
+                path: ['a', 'b', 0],
+                type: 'tree',
+                name: '{attributes C, D}',
+                children: [
+                  {
+                    id: 'a.b.0.c',
+                    path: ['a', 'b', 0, 'c'],
+                    type: 'leaf',
+                    name: 'C',
+                    value: 1
+                  },
+                  {
+                    id: 'a.b.0.d',
+                    path: ['a', 'b', 0, 'd'],
+                    type: 'leaf',
+                    name: 'D',
+                    value: 'dodo'
+                  }
+                ]
+              },
+              { id: 'a.b.1', path: ['a', 'b', 1], type: 'leaf', value: 'meuh' }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  // console.log(JSON.stringify(processed))
+  expect(processed).toStrictEqual(correctProcessed)
+  expect(true).toStrictEqual(true)
+})
+
+test('traverseJson and filter', () => {
+  const srcJson = {
+    r: 'roro',
+    a: { n: 'nono', b: [{ c: 1, d: 'dodo' }, 'meuh'] }
+  }
+  const process = (json, path, type, children) => {
+    const item = { path, type }
+    if (type === nodeTypes.LEAF) {
+      item.value = json
+    }
+    if (children) {
+      item.children = children
+    }
+    return item
+  }
+  const predicate = item =>
+    item?.value === 'dodo' || Object.keys(item?.children || {}).length > 0
+
+  const processAndFilter = (json, path, type, children) => {
+    const item = process(json, path, type, children)
+    return predicate(item) ? item : undefined
+  }
+  const processed = traverseJson(srcJson, processAndFilter)
+  const correctProcessed = {
+    path: [],
+    type: 'tree',
+    children: [
+      {
+        path: ['a'],
+        type: 'tree',
+        children: [
+          {
+            path: ['a', 'b'],
+            type: 'list',
+            children: [
+              {
+                path: ['a', 'b', 0],
+                type: 'tree',
+                children: [
+                  { path: ['a', 'b', 0, 'd'], value: 'dodo', type: 'leaf' }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  expect(processed).toStrictEqual(correctProcessed)
+})
+test('traverseJson and process', () => {
+  const srcJson = {
+    r: 'roro',
+    a: { n: 'nono', b: [{ c: 1, d: 'dodo' }, 'meuh'] }
+  }
+  const process = (json, path, type, children) => {
+    const item = { path, type }
+    if (type === nodeTypes.LEAF) {
+      item.value = json
+    }
+    if (children) {
+      item.children = children
+    }
+    return item
+  }
+  const processed = traverseJson(srcJson, process)
+  const correctProcessed = {
+    path: [],
+    type: 'tree',
+    children: [
+      { path: ['r'], value: 'roro', type: 'leaf' },
+      {
+        path: ['a'],
+        type: 'tree',
+        children: [
+          { path: ['a', 'n'], value: 'nono', type: 'leaf' },
+          {
+            path: ['a', 'b'],
+            type: 'list',
+            children: [
+              {
+                path: ['a', 'b', 0],
+                type: 'tree',
+                children: [
+                  { path: ['a', 'b', 0, 'c'], value: 1, type: 'leaf' },
+                  { path: ['a', 'b', 0, 'd'], value: 'dodo', type: 'leaf' }
+                ]
+              },
+              { path: ['a', 'b', 1], value: 'meuh', type: 'leaf' }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  expect(processed).toStrictEqual(correctProcessed)
+})
+
+test('traverseJson', () => {
+  const srcJson = {
+    r: 'roro',
+    a: { n: 'nono', b: [{ c: 1, d: 'dodo' }, { c: 2 }, 'meuh'] }
+  }
+  const list = []
+
+  const represent = (json, type) => {
+    switch (type) {
+      case nodeTypes.LEAF:
+        return json
+      case nodeTypes.TREE:
+        return `{${Object.keys(json).join(' ')}}`
+      case nodeTypes.LIST:
+        return `[${json.length}]`
+      default:
+        return undefined
+    }
+  }
+  const process = (json, path, type, children) => {
+    list.push([path, represent(json, type), type, !!children])
+  }
+  traverseJson(srcJson, process)
+  const correctList = [
+    [['r'], 'roro', 'leaf', false],
+    [['a', 'n'], 'nono', 'leaf', false],
+    [['a', 'b', 0, 'c'], 1, 'leaf', false],
+    [['a', 'b', 0, 'd'], 'dodo', 'leaf', false],
+    [['a', 'b', 0], '{c d}', 'tree', true],
+    [['a', 'b', 1, 'c'], 2, 'leaf', false],
+    [['a', 'b', 1], '{c}', 'tree', true],
+    [['a', 'b', 2], 'meuh', 'leaf', false],
+    [['a', 'b'], '[3]', 'list', true],
+    [['a'], '{n b}', 'tree', true],
+    [[], '{r a}', 'tree', true]
+  ]
+  expect(list).toStrictEqual(correctList)
+})
 
 test('simple itemifyJSON', () => {
   const json = { n: 'root' }
   const correctItems = [
     {
-      type: tree,
-      id: 2,
+      type: TREE,
+      id: '',
       path: [],
       name: '{attributes N}',
-      children: [{ id: 2, path: ['n'], value: 'root', type: leaf, name: 'N' }]
+      children: [{ id: 'n', path: ['n'], value: 'root', type: LEAF, name: 'N' }]
     }
   ]
   const items = itemifyJSON(JSON.stringify(json))
-
   expect(items).toStrictEqual(correctItems)
 })
 
-test('itemifyJSON with empty array/object', () => {
-  const json = { n: [], o: {} }
-  const correctItems = [
-    {
-      type: tree,
-      id: 3,
-      path: [],
-      name: '{attributes N, O}',
-      children: [
-        {
-          id: 2,
-          path: ['n'],
-          type: list,
-          name: 'N / [empty list]'
-        },
-        {
-          id: 3,
-          path: ['o'],
-          type: tree,
-          name: 'O / {no attributes}'
-        }
-      ]
-    }
-  ]
-  const items = itemifyJSON(JSON.stringify(json))
-
-  expect(items).toStrictEqual(correctItems)
-})
 test('complex itemifyJSON', () => {
   const json = {
     n: 'root',
@@ -54,72 +290,72 @@ test('complex itemifyJSON', () => {
   }
   const correctItems = [
     {
-      type: tree,
-      id: 11,
-      name: '{attributes N, A}',
+      id: '',
       path: [],
+      type: 'tree',
+      name: '{attributes N, A}',
       children: [
-        { id: 2, path: ['n'], value: 'root', type: leaf, name: 'N' },
+        { id: 'n', path: ['n'], type: 'leaf', name: 'N', value: 'root' },
         {
-          type: tree,
-          id: 11,
-          name: 'A / {attributes N, B}',
+          id: 'a',
           path: ['a'],
+          type: 'tree',
+          name: 'A / {attributes N, B}',
           children: [
             {
-              type: leaf,
-              id: 4,
+              id: 'a.n',
               path: ['a', 'n'],
+              type: 'leaf',
               name: 'N',
               value: 'child'
             },
             {
-              type: list,
-              id: 11,
-              name: 'B / [list with 3 items]',
+              id: 'a.b',
               path: ['a', 'b'],
+              type: 'list',
+              name: 'B / [list with 3 items]',
               children: [
                 {
+                  id: 'a.b.0',
+                  path: ['a', 'b', 0],
+                  type: 'tree',
+                  name: '{attributes C, D}',
                   children: [
                     {
-                      type: leaf,
-                      id: 7,
+                      id: 'a.b.0.c',
                       path: ['a', 'b', 0, 'c'],
+                      type: 'leaf',
                       name: 'C',
                       value: 1
                     },
                     {
-                      type: leaf,
-                      id: 8,
+                      id: 'a.b.0.d',
                       path: ['a', 'b', 0, 'd'],
+                      type: 'leaf',
                       name: 'D',
                       value: 'roro'
                     }
-                  ],
-                  type: tree,
-                  id: 8,
-                  path: ['a', 'b', 0],
-                  name: '{attributes C, D}'
+                  ]
                 },
                 {
+                  id: 'a.b.1',
+                  path: ['a', 'b', 1],
+                  type: 'tree',
+                  name: '{attributes C}',
                   children: [
                     {
-                      type: leaf,
-                      id: 10,
+                      id: 'a.b.1.c',
                       path: ['a', 'b', 1, 'c'],
+                      type: 'leaf',
                       name: 'C',
                       value: 2
                     }
-                  ],
-                  type: tree,
-                  id: 10,
-                  path: ['a', 'b', 1],
-                  name: '{attributes C}'
+                  ]
                 },
                 {
-                  type: leaf,
-                  id: 11,
+                  id: 'a.b.2',
                   path: ['a', 'b', 2],
+                  type: 'leaf',
                   value: 'meuh'
                 }
               ]
@@ -133,6 +369,57 @@ test('complex itemifyJSON', () => {
   expect(items).toStrictEqual(correctItems)
 })
 
+test('itemifyJSON with empty array/object', () => {
+  const json = { n: [], o: {} }
+  const correctItems = [
+    {
+      type: TREE,
+      id: '',
+      path: [],
+      name: '{attributes N, O}',
+      children: [
+        {
+          id: 'n',
+          path: ['n'],
+          type: LIST,
+          name: 'N / [empty list]'
+        },
+        {
+          id: 'o',
+          path: ['o'],
+          type: TREE,
+          name: 'O / {no attributes}'
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSON(JSON.stringify(json))
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('itemifyJSON with empty array/object and filter', () => {
+  const json = { nono: [], o: {} }
+  const correctItems = [
+    {
+      id: '',
+      type: TREE,
+      path: [],
+      name: '{attributes Nono, O}',
+      children: [
+        {
+          id: 'nono',
+          path: ['nono'],
+          type: LIST,
+          name: 'Nono / [empty list]'
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSON(JSON.stringify(json), 'no')
+
+  expect(items).toStrictEqual(correctItems)
+})
+
 test('complex itemifyJSON with filter that matches', () => {
   const json = {
     n: 'root',
@@ -140,37 +427,37 @@ test('complex itemifyJSON with filter that matches', () => {
   }
   const correctItems = [
     {
-      type: tree,
-      id: 11,
+      type: TREE,
+      id: '',
       name: '{attributes N, A}',
       path: [],
       children: [
         {
-          type: tree,
-          id: 11,
+          type: TREE,
+          id: 'a',
           name: 'A / {attributes N, B}',
           path: ['a'],
           children: [
             {
-              type: list,
-              id: 11,
-              name: 'B / [list with 1 item]',
+              type: LIST,
+              id: 'a.b',
+              name: 'B / [list with 3 items]',
               path: ['a', 'b'],
               children: [
                 {
+                  id: 'a.b.0',
+                  type: TREE,
+                  path: ['a', 'b', 0],
+                  name: '{attributes C, D}',
                   children: [
                     {
-                      type: leaf,
-                      id: 8,
+                      type: LEAF,
+                      id: 'a.b.0.d',
                       path: ['a', 'b', 0, 'd'],
                       name: 'D',
                       value: 'roro'
                     }
-                  ],
-                  type: tree,
-                  id: 8,
-                  path: ['a', 'b', 0],
-                  name: '{attributes C, D}'
+                  ]
                 }
               ]
             }
@@ -197,24 +484,239 @@ test('complex itemifyJSON with filter that does not match', () => {
   expect(items).toStrictEqual(correctItems)
 })
 
+test('complex itemifyJSON old', () => {
+  const json = {
+    n: 'root',
+    a: { n: 'child', b: [{ c: 1, d: 'roro' }, { c: 2 }, 'meuh'] }
+  }
+  const correctItems = [
+    {
+      id: 11,
+      name: '{attributes N, A}',
+      path: [],
+      type: 'tree',
+      children: [
+        { id: 2, value: 'root', type: 'leaf', path: ['n'], name: 'N' },
+        {
+          id: 11,
+          name: 'A / {attributes N, B}',
+          path: ['a'],
+          type: 'tree',
+          children: [
+            {
+              id: 4,
+              value: 'child',
+              type: 'leaf',
+              path: ['a', 'n'],
+              name: 'N'
+            },
+            {
+              id: 11,
+              path: ['a', 'b'],
+              name: 'B / [list with 3 items]',
+              type: 'list',
+              children: [
+                {
+                  id: 8,
+                  name: '{attributes C, D}',
+                  path: ['a', 'b', 0],
+                  type: 'tree',
+                  children: [
+                    {
+                      id: 7,
+                      value: 1,
+                      type: 'leaf',
+                      path: ['a', 'b', 0, 'c'],
+                      name: 'C'
+                    },
+                    {
+                      id: 8,
+                      value: 'roro',
+                      type: 'leaf',
+                      path: ['a', 'b', 0, 'd'],
+                      name: 'D'
+                    }
+                  ]
+                },
+                {
+                  id: 10,
+                  name: '{attributes C}',
+                  path: ['a', 'b', 1],
+                  type: 'tree',
+                  children: [
+                    {
+                      id: 10,
+                      value: 2,
+                      type: 'leaf',
+                      path: ['a', 'b', 1, 'c'],
+                      name: 'C'
+                    }
+                  ]
+                },
+                { id: 11, value: 'meuh', type: 'leaf', path: ['a', 'b', 2] }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSONOld(JSON.stringify(json))
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('simple itemifyJSON old', () => {
+  const json = { n: 'root' }
+  const correctItems = [
+    {
+      type: TREE,
+      id: 2,
+      path: [],
+      name: '{attributes N}',
+      children: [{ id: 2, path: ['n'], value: 'root', type: LEAF, name: 'N' }]
+    }
+  ]
+  const items = itemifyJSONOld(JSON.stringify(json))
+
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('itemifyJSON with empty array/object old', () => {
+  const json = { n: [], o: {} }
+  const correctItems = [
+    {
+      type: TREE,
+      id: 3,
+      path: [],
+      name: '{attributes N, O}',
+      children: [
+        {
+          path: ['n'],
+          id: 2,
+          type: LIST,
+          name: 'N / [empty list]'
+        },
+        {
+          id: 3,
+          path: ['o'],
+          type: TREE,
+          name: 'O / {no attributes}'
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSONOld(JSON.stringify(json))
+
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('itemifyJSON with empty array/object and filter old', () => {
+  const json = { nono: [], o: {} }
+  const correctItems = [
+    {
+      type: TREE,
+      id: 3,
+      path: [],
+      name: '{attributes Nono, O}',
+      children: [
+        {
+          // TODO this is what we want:
+          //
+          // path: ['nono'],
+          // type: LIST,
+          // name: 'Nono / [empty list]'
+          name: 'Nono'
+        }
+      ]
+    }
+  ]
+  const items = itemifyJSONOld(JSON.stringify(json), 'no')
+
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('complex itemifyJSON with filter that matches old', () => {
+  const json = {
+    n: 'root',
+    a: { n: 'child', b: [{ c: 1, d: 'roro' }, { c: 2 }, 'meuh'] }
+  }
+  const correctItems = [
+    {
+      id: 11,
+      name: '{attributes N, A}',
+      path: [],
+      type: 'tree',
+      children: [
+        {
+          id: 11,
+          name: 'A / {attributes N, B}',
+          path: ['a'],
+          type: 'tree',
+          children: [
+            {
+              id: 11,
+              path: ['a', 'b'],
+              name: 'B / [list with 1 item]',
+              type: 'list',
+              children: [
+                {
+                  id: 8,
+                  name: '{attributes C, D}',
+                  path: ['a', 'b', 0],
+                  type: 'tree',
+                  children: [
+                    {
+                      id: 8,
+                      value: 'roro',
+                      type: 'leaf',
+                      path: ['a', 'b', 0, 'd'],
+                      name: 'D'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+  let items = itemifyJSONOld(JSON.stringify(json), 'roro')
+  expect(items).toStrictEqual(correctItems)
+  items = itemifyJSONOld(JSON.stringify(json), 'ror')
+  expect(items).toStrictEqual(correctItems)
+  items = itemifyJSONOld(JSON.stringify(json), 'ROR')
+  expect(items).toStrictEqual(correctItems)
+})
+
+test('complex itemifyJSON with filter that does not match old', () => {
+  const json = {
+    n: 'root',
+    a: { n: 'child', b: [{ c: 1, d: 'roro' }, { c: 2 }, 'meuh'] }
+  }
+  const correctItems = [[]]
+  const items = itemifyJSONOld(JSON.stringify(json), 'XXX')
+  expect(items).toStrictEqual(correctItems)
+})
+
 test('item JsonPath for object', () => {
   const json = { a: { b: 'roro' } }
   const correctItems = [
     {
-      type: tree,
-      id: 3,
+      id: '',
+      type: TREE,
       name: '{attributes A}',
       path: [],
       children: [
         {
-          type: tree,
-          id: 3,
+          id: 'a',
+          type: TREE,
           path: ['a'],
           name: 'A / {attributes B}',
           children: [
             {
-              type: leaf,
-              id: 3,
+              id: 'a.b',
+              type: LEAF,
               name: 'B',
               path: ['a', 'b'],
               value: 'roro'
@@ -238,20 +740,20 @@ test('item JsonPath for array element', () => {
   const json = { c: ['toto'] }
   const correctItems = [
     {
-      type: tree,
-      id: 3,
+      id: '',
+      type: TREE,
       name: '{attributes C}',
       path: [],
       children: [
         {
-          type: list,
-          id: 3,
+          type: LIST,
+          id: 'c',
           name: 'C / [list with 1 item]',
           path: ['c'],
           children: [
             {
-              type: leaf,
-              id: 3,
+              id: 'c.0',
+              type: LEAF,
               path: ['c', 0],
               value: 'toto'
             }
@@ -275,44 +777,44 @@ test('item JsonPath for big array element', () => {
   }
   const correctItems = [
     {
-      type: tree,
-      id: 16,
-      name: '{attributes C}',
+      id: '',
       path: [],
+      type: 'tree',
+      name: '{attributes C}',
       children: [
         {
-          id: 14,
-          type: list,
+          id: 'c',
           path: ['c'],
+          type: 'list',
           name: 'C / [list with 12 items]',
           children: [
             {
-              id: 15,
-              type: list,
+              id: 'c[0:10]',
               name: '[elements 1 - 10]',
               path: ['c'],
               children: [
-                { id: 3, value: 1, type: leaf, path: ['c', 0] },
-                { id: 4, value: 2, type: leaf, path: ['c', 1] },
-                { id: 5, value: 3, type: leaf, path: ['c', 2] },
-                { id: 6, value: 4, type: leaf, path: ['c', 3] },
-                { id: 7, value: 5, type: leaf, path: ['c', 4] },
-                { id: 8, value: 6, type: leaf, path: ['c', 5] },
-                { id: 9, value: 7, type: leaf, path: ['c', 6] },
-                { id: 10, value: 8, type: leaf, path: ['c', 7] },
-                { id: 11, value: 9, type: leaf, path: ['c', 8] },
-                { id: 12, value: 10, type: leaf, path: ['c', 9] }
-              ]
+                { id: 'c.0', path: ['c', 0], type: 'leaf', value: 1 },
+                { id: 'c.1', path: ['c', 1], type: 'leaf', value: 2 },
+                { id: 'c.2', path: ['c', 2], type: 'leaf', value: 3 },
+                { id: 'c.3', path: ['c', 3], type: 'leaf', value: 4 },
+                { id: 'c.4', path: ['c', 4], type: 'leaf', value: 5 },
+                { id: 'c.5', path: ['c', 5], type: 'leaf', value: 6 },
+                { id: 'c.6', path: ['c', 6], type: 'leaf', value: 7 },
+                { id: 'c.7', path: ['c', 7], type: 'leaf', value: 8 },
+                { id: 'c.8', path: ['c', 8], type: 'leaf', value: 9 },
+                { id: 'c.9', path: ['c', 9], type: 'leaf', value: 10 }
+              ],
+              type: 'list'
             },
             {
-              id: 16,
-              type: list,
+              id: 'c[10:12]',
               name: '[elements 11 - 12]',
               path: ['c'],
               children: [
-                { id: 13, value: 11, type: leaf, path: ['c', 10] },
-                { id: 14, value: 12, type: leaf, path: ['c', 11] }
-              ]
+                { id: 'c.10', path: ['c', 10], type: 'leaf', value: 11 },
+                { id: 'c.11', path: ['c', 11], type: 'leaf', value: 12 }
+              ],
+              type: 'list'
             }
           ]
         }

--- a/utils/json.worker.js
+++ b/utils/json.worker.js
@@ -1,3 +1,3 @@
-import itemifyJSON from '~/utils/json'
+import { itemifyJSON } from '~/utils/json'
 
 onmessage = message => postMessage(itemifyJSON(...message.data))


### PR DESCRIPTION
The original itemifyJSON was hard enough for me to understand that I didn't see how to fix some bugs.

The rewritten version is hopefully easier to understand also for other people than  myself.

Two minor bugs were fixed in the process:
- missing icon in the json viewer for empty objects/lists
- item ids were not unique

The old function is still there under the name **itemifyJSONOld**

If you need to go back quickly to the old functionality, call itemifyJSONOld instead of itemifyJSON in [json.worker.js](https://github.com/hestiaAI/hestialabs-experiences/blob/master/utils/json.worker.js)