### PR TITLE
feat: relaxed file restrictions

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -248,11 +248,19 @@ export default {
       const start = new Date()
 
       await this.fileManager.init(uppyFiles, this.multiple)
-      let processedFiles
-      try {
-        processedFiles = await this.fileManager.preprocessFiles(this.files)
-      } catch (error) {
-        this.handleError(error)
+
+      // Check that the required files are present in the archive
+      const missing = this.files
+        .map(filePathGlob => [
+          filePathGlob,
+          this.fileManager.findMatchingFilePaths(filePathGlob).length
+        ])
+        .filter(([_, n]) => n === 0)
+        .map(([filePathGlob, _]) => filePathGlob)
+      if (missing.length > 0) {
+        this.message = `Missing file(s): ${missing.join(', ')}`
+        this.error = true
+        this.progress = false
         return
       }
 
@@ -263,6 +271,9 @@ export default {
 
       if (this.isRdfNeeded && this.yarrrml) {
         try {
+          const processedFiles = await this.fileManager.preprocessFiles(
+            this.files
+          )
           this.rml = await parseYarrrml(this.yarrrml)
           await rdfUtils.generateRDF(this.rml, processedFiles)
         } catch (error) {

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -4,17 +4,8 @@
   "dataPortal": "https://www.facebook.com/help/212802592074644",
   "ext": "zip",
   "data": [],
-  "files": [
-    "apps_and_websites_off_of_facebook/your_off-facebook_activity.json",
-    "your_topics/your_topics.json",
-    "ads_information/advertisers_you've_interacted_with.json",
-    "ads_information/advertisers_who_uploaded_a_contact_list_with_your_information.json"
-  ],
   "preprocessors": {
-    "apps_and_websites_off_of_facebook/your_off-facebook_activity.json": "facebook",
-    "your_topics/your_topics.json": "facebook",
-    "ads_information/advertisers_you've_interacted_with.json": "facebook",
-    "ads_information/advertisers_who_uploaded_a_contact_list_with_your_information.json": "facebook"
+    "**/*.json": "facebook"
   },
   "allowMissingFiles": true,
   "collaborator": {

--- a/manifests/experiences/twitter/__tests__/database.test.js
+++ b/manifests/experiences/twitter/__tests__/database.test.js
@@ -42,65 +42,12 @@ async function getDatabase(adImpressions, adEngagements) {
 }
 
 describe('with incomplete samples', () => {
-  beforeAll(async () => {
+  test('the database builder creates the tables without error', async () => {
     await getDatabase(
       missingAttributesImpressions,
       missingAttributesEngagements
     )
-  })
-
-  afterAll(() => {
     db.close()
-  })
-
-  test('the database builder creates the tables correctly', () => {
-    let result, expected
-
-    // Table twitterAds
-    result = db.select('SELECT * FROM twitterAds')
-    expected = {
-      headers: ['id', 'tweetId', 'advertiserName', 'time', 'engagement'],
-      items: [
-        {
-          id: 0,
-          tweetId: null,
-          advertiserName: null,
-          time: null,
-          engagement: 0
-        },
-        {
-          id: 1,
-          tweetId: null,
-          advertiserName: null,
-          time: null,
-          engagement: 1
-        }
-      ]
-    }
-    arrayEqualNoOrder(result.headers, expected.headers)
-    arrayEqualNoOrder(result.items, expected.items)
-
-    // Table twitterCriteria
-    result = db.select('SELECT * FROM twitterCriteria')
-    expected = {
-      headers: ['id', 'adId', 'targetingType', 'targetingValue'],
-      items: [
-        {
-          id: 0,
-          adId: 0,
-          targetingType: null,
-          targetingValue: null
-        },
-        {
-          id: 1,
-          adId: 1,
-          targetingType: null,
-          targetingValue: null
-        }
-      ]
-    }
-    arrayEqualNoOrder(result.headers, expected.headers)
-    arrayEqualNoOrder(result.items, expected.items)
   })
 })
 

--- a/manifests/experiences/twitter/__tests__/database.test.js
+++ b/manifests/experiences/twitter/__tests__/database.test.js
@@ -23,17 +23,17 @@ function runQuery(sqlFilePath) {
 async function getDatabase(adImpressions, adEngagements) {
   const fileManager = new FileManager(
     {
-      'data/ad-impressions.js': preprocessors.twitter,
-      'data/ad-engagements.js': preprocessors.twitter
+      'test/data/ad-impressions.js': preprocessors.twitter,
+      'test/data/ad-engagements.js': preprocessors.twitter
     },
     true
   )
   const fileImpressions = mockFile(
-    'data/ad-impressions.js',
+    'test/data/ad-impressions.js',
     JSON.stringify(adImpressions)
   )
   const fileEngagements = mockFile(
-    'data/ad-engagements.js',
+    'test/data/ad-engagements.js',
     JSON.stringify(adEngagements)
   )
   await fileManager.init([fileImpressions, fileEngagements], true)

--- a/manifests/experiences/twitter/database.js
+++ b/manifests/experiences/twitter/database.js
@@ -1,6 +1,17 @@
 import { JSONPath } from 'jsonpath-plus'
 import { DB } from '~/utils/sql'
 
+async function getFileFromGlob(glob, fileManager) {
+  const matches = fileManager.findMatchingFilePaths(glob)
+  if (matches.length === 0) {
+    throw new Error(`Missing file: ${glob}`)
+  } else if (matches.length > 1) {
+    console.warn(`File ${glob} was found multiple times`)
+  }
+  const file = await fileManager.getPreprocessedText(matches[0])
+  return JSON.parse(file)
+}
+
 export default async function databaseBuilder(fileManager) {
   const db = new DB()
   await db.init()
@@ -19,11 +30,13 @@ export default async function databaseBuilder(fileManager) {
     ['targetingValue', 'TEXT']
   ])
 
-  const impressionsFile = JSON.parse(
-    await fileManager.getPreprocessedText('data/ad-impressions.js')
+  const impressionsFile = await getFileFromGlob(
+    '**/ad-impressions.js',
+    fileManager
   )
-  const engagementsFile = JSON.parse(
-    await fileManager.getPreprocessedText('data/ad-engagements.js')
+  const engagementsFile = await getFileFromGlob(
+    '**/ad-engagements.js',
+    fileManager
   )
   const impressions = JSONPath({
     path: '$.*.ad.adsUserData.adImpressions.impressions[*]',

--- a/manifests/experiences/twitter/twitter.json
+++ b/manifests/experiences/twitter/twitter.json
@@ -4,11 +4,11 @@
   "dataPortal": "https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive",
   "ext": "zip",
   "data": ["twitter.zip", "twitter-sample.zip"],
-  "files": ["data/ad-impressions.js", "data/ad-engagements.js"],
+  "files": ["**/ad-impressions.js", "**/ad-engagements.js"],
   "preprocessors": {
-    "data/ad-impressions.js": "twitter",
-    "data/ad-engagements.js": "twitter",
-    "data/personalization.js": "twitter"
+    "**/ad-impressions.js": "twitter",
+    "**/ad-engagements.js": "twitter",
+    "**/personalization.js": "twitter"
   },
   "collaborator": {
     "title": "The Eyeballs Collective",

--- a/manifests/experiences/uber/pipeline.js
+++ b/manifests/experiences/uber/pipeline.js
@@ -5,17 +5,24 @@ import {
 } from '~/manifests/generic-pipelines'
 
 async function tripsData({ fileManager }) {
-  return await fileManager.getCsvItems('Uber Data/Rider/trips_data.csv')
+  const path = fileManager.findMatchingFilePaths(
+    '**/Uber Data/Rider/trips_data.csv'
+  )[0]
+  return await fileManager.getCsvItems(path)
 }
 
 async function tripsRawData({ fileManager }) {
-  return await fileManager.getText('Uber Data/Rider/trips_data.csv')
+  const path = fileManager.findMatchingFilePaths(
+    '**/Uber Data/Rider/trips_data.csv'
+  )[0]
+  return await fileManager.getText(path)
 }
 
 async function tripsGraphData({ fileManager }) {
-  const tripsData = await fileManager.getCsvItems(
-    'Uber Data/Rider/trips_data.csv'
-  )
+  const path = fileManager.findMatchingFilePaths(
+    '**/Uber Data/Rider/trips_data.csv'
+  )[0]
+  const tripsData = await fileManager.getCsvItems(path)
   const filteredValues = tripsData.items.reduce((acc, d) => {
     // filter non trips data
     if (

--- a/manifests/experiences/uber/uber.json
+++ b/manifests/experiences/uber/uber.json
@@ -4,7 +4,7 @@
   "icon": "uber.png",
   "dataPortal": "https://help.uber.com/ubereats/article/request-a-copy-of-your-uber-data",
   "ext": "zip",
-  "files": ["Uber Data/Rider/trips_data.csv"],
+  "files": ["**/Uber Data/Rider/trips_data.csv"],
   "data": ["uber-trips.zip"],
   "defaultView": [
     {


### PR DESCRIPTION
Partly address #353 

Now the files that are required in a zip archive can be defined as globs. 

The Twitter and Facebook pipelines are adapted so that the files that we process can be at any depth in the archive.

Note that the preprocessing also had to be adapted for more flexibility, now it can also use globs. Close #479

I'm not sure if we should still show to the user the list of files that are required (#480). It may give the impression that we are only using these files, while in practice we are using all those that we can process (in the generic date/location viewer). In my opinion, it would be more informative to give this information in each experience (i.e. show "this experience uses the files ad-impressions.js and ad-engagements.js", somewhere not too visible).