### PR TITLE
Feat: simplify table options

### DIFF
--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -72,7 +72,7 @@
           "filePath": "ads_information/advertisers_who_uploaded_a_contact_list_with_your_information.json",
           "jsonPath": "$.custom_audiences_all_types_v2[*]"
         },
-        "properties": [
+        "columns": [
           {
             "name": "Advertiser",
             "jsonPath": "advertiser_name"

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -75,27 +75,19 @@
         "properties": [
           {
             "name": "Advertiser",
-            "field": "advertiser_name",
-            "type": "string",
-            "required": true
+            "jsonPath": "advertiser_name"
           },
           {
             "name": "has_data_file_custom_audience",
-            "field": "has_data_file_custom_audience",
-            "type": "boolean",
-            "required": true
+            "jsonPath": "has_data_file_custom_audience"
           },
           {
             "name": "has_remarketing_custom_audience",
-            "field": "has_remarketing_custom_audience",
-            "type": "boolean",
-            "required": true
+            "jsonPath": "has_remarketing_custom_audience"
           },
           {
             "name": "has_in_person_store_visit",
-            "field": "has_in_person_store_visit",
-            "type": "boolean",
-            "required": true
+            "jsonPath": "has_in_person_store_visit"
           }
         ]
       },

--- a/manifests/generic-pipelines.js
+++ b/manifests/generic-pipelines.js
@@ -443,29 +443,13 @@ function makeTableItem(object, options) {
   const item = {}
   options.properties.forEach(p => {
     // get all entries that satisfy the given field JSONPATH
+    const path = p.jsonPath || p.name
     const value = JSONPath({
-      path: p.field,
+      path,
       json: object,
       wrap: true
     })
-
-    // Cast value to specified format, may need to handle errors
-    switch (p.type) {
-      case 'date':
-        item[p.name] = timeParse(p.format)(value)
-        break
-      case 'string':
-        item[p.name] = String(value)
-        break
-      case 'number':
-        item[p.name] = Number(value)
-        break
-      case 'boolean':
-        item[p.name] = Boolean(value)
-        break
-      default:
-        item[p.name] = value
-    }
+    item[p.name] = value
   })
   return item
 }

--- a/manifests/generic-pipelines.js
+++ b/manifests/generic-pipelines.js
@@ -406,8 +406,8 @@ async function jsonToTableConverter({
 }
 
 export function makeTableData(objects, options) {
-  if (options?.properties) {
-    const headers = options.properties.map(p => p.name)
+  if (options?.columns) {
+    const headers = options.columns.map(p => p.name)
     const items = objects.map(e => makeTableItem(e, options))
     return { headers, items }
   }
@@ -441,7 +441,7 @@ export function makeTableData(objects, options) {
 
 function makeTableItem(object, options) {
   const item = {}
-  options.properties.forEach(p => {
+  options.columns.forEach(p => {
     // get all entries that satisfy the given field JSONPATH
     const path = p.jsonPath || p.name
     const value = JSONPath({
@@ -449,7 +449,7 @@ function makeTableItem(object, options) {
       json: object,
       wrap: true
     })
-    item[p.name] = value
+    item[p.name] = value[0] || ''
   })
   return item
 }

--- a/manifests/generic-pipelines.test.js
+++ b/manifests/generic-pipelines.test.js
@@ -5,8 +5,19 @@ test('jsonToTableConverter with properties', async () => {
   const fileName = 'comments_and_reactions/comments.json'
   const content = {
     comments_v2: [
-      { timestamp: 1000000000, comment: 'one comment', name: 'hello' },
-      { timestamp: 1000000001, comment: 'another comment', name: 'toto' }
+      {
+        timestamp: 1000000000,
+        comment: 'one comment',
+        name: 'hello',
+        ne: { foo: 'boo' },
+        list: ['one', 'two']
+      },
+      {
+        timestamp: 1000000001,
+        comment: 'another comment',
+        name: 'toto',
+        list: ['three', 'four']
+      }
     ]
   }
   const fileManager = await mockFileManager(fileName, JSON.stringify(content))
@@ -16,18 +27,21 @@ test('jsonToTableConverter with properties', async () => {
       filePath: 'comments_and_reactions/comments.json',
       jsonPath: '$.comments_v2[*]'
     },
-    properties: [
+    columns: [
       {
         name: 'Timestamp',
-        field: 'timestamp',
-        type: 'number',
-        required: true
+        jsonPath: 'timestamp'
       },
       {
-        name: 'First comment',
-        field: 'comment',
-        type: 'string',
-        required: true
+        name: 'comment'
+      },
+      {
+        name: 'Nested',
+        jsonPath: 'ne.foo'
+      },
+      {
+        name: 'list0',
+        jsonPath: 'list[0]'
       }
     ]
   }
@@ -38,10 +52,20 @@ test('jsonToTableConverter with properties', async () => {
 
   const tableData = await jsonToTableConverter({ fileManager, options })
   const correct = {
-    headers: ['Timestamp', 'First comment'],
+    headers: ['Timestamp', 'comment', 'Nested', 'list0'],
     items: [
-      { Timestamp: 1000000000, 'First comment': 'one comment' },
-      { Timestamp: 1000000001, 'First comment': 'another comment' }
+      {
+        Timestamp: 1000000000,
+        comment: 'one comment',
+        Nested: 'boo',
+        list0: 'one'
+      },
+      {
+        Timestamp: 1000000001,
+        comment: 'another comment',
+        Nested: '',
+        list0: 'three'
+      }
     ]
   }
   expect(tableData).toStrictEqual(correct)

--- a/manifests/jsonToTableSchema.js
+++ b/manifests/jsonToTableSchema.js
@@ -30,34 +30,11 @@ export default {
             type: 'string'
           },
           // JSONPath to access the value (it can be nested or not)
-          field: {
+          jsonPath: {
             type: 'string'
-          },
-          // type of the value, allow to cast specific types
-          type: {
-            default: 'object',
-            enum: ['string', 'date', 'number', 'object', 'list', 'boolean']
-          },
-          // format is required when the type is "date",
-          // we use https://github.com/d3/d3-time-format to format dates
-          format: {
-            type: 'string'
-          },
-          // When required is set to true, an error message will be sent
-          // if a value is not found, in any case empty values are set to null
-          required: {
-            type: 'boolean'
           }
         },
-        required: ['name', 'field', 'type', 'required'],
-        anyOf: [
-          {
-            not: {
-              properties: { type: { const: 'date' } }
-            }
-          },
-          { required: ['format'] }
-        ]
+        required: ['name']
       }
     }
   },

--- a/manifests/jsonToTableSchema.js
+++ b/manifests/jsonToTableSchema.js
@@ -20,7 +20,7 @@ export default {
       required: ['filePath', 'jsonPath']
     },
     // here we define the properties of each column
-    properties: {
+    columns: {
       type: 'array',
       items: {
         type: 'object',


### PR DESCRIPTION
To make working with configurable tables as in #481, I propose simplifying the syntax to configure tables.

Maybe you can find a way to simplify them even further.