### PR TITLE
fix: random crashes

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -198,11 +198,7 @@ export default {
       success: false,
       message: '',
       rml: '',
-      fileManager: new FileManager(
-        this.preprocessors,
-        this.allowMissingFiles,
-        fileManagerWorkers
-      ),
+      fileManager: null,
       db: null
     }
   },
@@ -256,6 +252,14 @@ export default {
       this.progress = true
       const start = new Date()
 
+      // Clean vuex state before changing the filemanager
+      this.$store.commit('setFileExplorerCurrentItem', {})
+
+      this.fileManager = new FileManager(
+        this.preprocessors,
+        this.allowMissingFiles,
+        fileManagerWorkers
+      )
       await this.fileManager.init(uppyFiles, this.multiple)
 
       // Check that the required files are present in the archive

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -204,7 +204,10 @@ export default {
     path() {
       // TODO avoid code duplication with viewer/mixin-path
       // maybe by setting path as an attribute on every viewer
-      return URL.createObjectURL(this.fileManager.fileDict[this.filename])
+      if (this.fileManager.fileDict[this.filename]) {
+        return URL.createObjectURL(this.fileManager.fileDict[this.filename])
+      }
+      return ''
     },
     componentForType() {
       const { fileType } = this

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -123,6 +123,7 @@
 
 <script>
 import _ from 'lodash'
+import { mapState } from 'vuex'
 import FileManager from '~/utils/file-manager.js'
 import { jsonToTableConverter } from '~/manifests/generic-pipelines'
 
@@ -160,6 +161,7 @@ export default {
     }
   },
   computed: {
+    ...mapState(['fileExplorerCurrentItem']),
     active: {
       get() {
         return _.has(this.selectedItem, 'filename') ? [this.selectedItem] : []
@@ -178,7 +180,7 @@ export default {
       }
     },
     selectedItem() {
-      const item = this.$store.getters.fileExplorerCurrentItem
+      const item = this.fileExplorerCurrentItem
       if (_.has(item, 'filename')) {
         if (!_.has(item, 'type')) {
           return this.searchItemWithFilename(item.filename)

--- a/store/index.js
+++ b/store/index.js
@@ -47,10 +47,7 @@ export const getters = {
     state =>
     ({ params: { key } }) => {
       return state.manifestMap[key] || {}
-    },
-  fileExplorerCurrentItem(state) {
-    return state.fileExplorerCurrentItem
-  }
+    }
 }
 
 export const mutations = {


### PR DESCRIPTION
These are tentative fixes for crashes that I couldn't reproduce reliably. I'm not sure if every change is really needed, but it seems to fix (or at least reduce) the crashes. I don't have time to look at it more carefully because it should be merged quickly for the deep dives.

The crashes happened mostly in the File Explorer, when you had already opened files in another company (e.g. Tinder) and you go to another one (e.g. Tracker Control). It seems that the file manager and the store were left in a dirty state