### PR TITLE
fix: convert timestamps to date strings in json viewers + improve date detection

### DIFF
--- a/components/unit/filterable-table/UnitFilterableTable.vue
+++ b/components/unit/filterable-table/UnitFilterableTable.vue
@@ -100,6 +100,7 @@
 import { writeToString } from '@fast-csv/format'
 import { processError } from '@/utils/utils'
 import { formatObject, formatArray } from '@/utils/json'
+import { toDateString } from '@/utils/dates'
 export default {
   name: 'UnitFilterableTable',
   props: {
@@ -164,21 +165,13 @@ export default {
   methods: {
     formatItemAsString(itemProps) {
       const { header, value } = itemProps
-      const assumeDate = ['date', 'time'].find(d =>
-        header.value.toLowerCase().includes(d)
-      )
-      if (assumeDate) {
-        return new Date(value).getFullYear() > 1980
-          ? new Date(value).toLocaleString()
-          : new Date(value * 1000).toLocaleString()
-      }
       if (Array.isArray(value)) {
         return formatArray(value)
       }
       if (typeof value === 'object') {
         return formatObject(value)
       }
-      return value
+      return toDateString(header.value, value)
     },
     async exportCSV() {
       this.progress = true

--- a/utils/dates.js
+++ b/utils/dates.js
@@ -1,5 +1,13 @@
+export function isValidDate(d) {
+  return d instanceof Date && !isNaN(d) && d.getFullYear() !== 1970
+}
 /**
  * Convert the given value to a formated date string depending on it's name
+ * If the name include date or time we assume that we can convert it with
+ * javascript Date object, then if the year founded after conversion is 1970,
+ * the starting date of unix timestamps, we assume that the timestamp is in
+ * seconds instead of milliseconds finally we return the value inchanged if
+ * we didnt succeed to convert it properly
  * @param {String} name the attribite name of the given value
  * @param {Any} value the value to convert
  * @returns the value transformed to local date string or the value inchanged if not possible
@@ -7,10 +15,10 @@
 export function toDateString(name, value) {
   const assumeDate = ['date', 'time'].find(d => name.toLowerCase().includes(d))
   if (assumeDate) {
-    return new Date(value).getFullYear() > 1980
-      ? new Date(value).toLocaleString()
-      : new Date(value * 1000).toLocaleString()
-  } else {
-    return value
+    let date = new Date(value)
+    if (isValidDate(date)) return date.toLocaleString()
+    date = new Date(value * 1000)
+    if (isValidDate(date)) return date.toLocaleString()
   }
+  return value
 }

--- a/utils/dates.js
+++ b/utils/dates.js
@@ -1,0 +1,16 @@
+/**
+ * Convert the given value to a formated date string depending on it's name
+ * @param {String} name the attribite name of the given value
+ * @param {Any} value the value to convert
+ * @returns the value transformed to local date string or the value inchanged if not possible
+ */
+export function toDateString(name, value) {
+  const assumeDate = ['date', 'time'].find(d => name.toLowerCase().includes(d))
+  if (assumeDate) {
+    return new Date(value).getFullYear() > 1980
+      ? new Date(value).toLocaleString()
+      : new Date(value * 1000).toLocaleString()
+  } else {
+    return value
+  }
+}

--- a/utils/json.js
+++ b/utils/json.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-
+import { toDateString } from '@/utils/dates'
 export function filterCondition(item, filter) {
   filter = filter.toLowerCase()
   return (
@@ -189,7 +189,7 @@ export function processJsonNode(json, path, type, processedChildren) {
     if (attrName) {
       item.name = attrName
     }
-    item.value = json
+    item.value = toDateString(attrName, json)
   } else if (type === LIST) {
     const description = formatArray(json)
     item.name = attrName ? `${attrName} / ${description}` : description


### PR DESCRIPTION
This PR is related to #375 

Add date translation feature to json viewer + improve code quality + improve date detection in both tables and json viewers.

To detect dates we try to convert the value with the Javascript Date constructor, we check if this result gives a valid date and then to make sure it is not a timestamp in seconds we check that the year is not 1970 (starting year of UNIX timestamps). If all checks pass, we transform the date into a local date string format, otherwise we return the value unchanged. This solution will fail only for dates from 1970, but this does not represent many use cases for us.