### PR TITLE
fix: UI refactoring

### DIFF
--- a/components/TheAppBar.vue
+++ b/components/TheAppBar.vue
@@ -16,6 +16,18 @@
           <VIcon>$vuetify.icons.mdiHome</VIcon>
         </VBtn>
         <VSpacer />
+        <div class="d-flex">
+          <VImg
+            max-width="30"
+            :src="company.icon"
+            :lazy-src="company.icon"
+            contain
+          />
+          <h3 class="ml-3">
+            {{ company.title }}
+          </h3>
+        </div>
+        <VSpacer />
         <a
           v-if="collaborator"
           :href="collaborator.url"
@@ -69,17 +81,23 @@
 
 <script>
 import { mapGetters } from 'vuex'
-
 export default {
   data() {
     return {
-      drawer: false
+      drawer: false,
+      selected: ''
     }
   },
   computed: {
-    ...mapGetters(['manifest']),
+    ...mapGetters(['manifest', 'enabledExperiences']),
     collaborator() {
       return this.manifest(this.$route).collaborator
+    },
+    company() {
+      return {
+        title: this.manifest(this.$route).title,
+        icon: this.manifest(this.$route).icon
+      }
     }
   }
 }

--- a/components/TheAppBar.vue
+++ b/components/TheAppBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <VAppBar fixed app color="white" height="75" style="z-index: 2500">
+    <VAppBar fixed app color="white" height="60" style="z-index: 2500">
       <VAppBarNavIcon
         aria-label="Open navigation menu"
         @click.stop="drawer = !drawer"

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -16,7 +16,7 @@
           class="fixed-tabs-bar"
         >
           <VTab>Upload</VTab>
-          <VTab :disabled="!success">Summary</VTab>
+          <VTab :disabled="!success" href="#summary">Summary</VTab>
           <VTab :disabled="!success">Files</VTab>
           <VTab
             v-for="(el, index) in defaultView"
@@ -29,42 +29,40 @@
         </VTabs>
         <VTabsItems v-model="tab">
           <VTabItem>
-            <div class="tabItem">
-              <VCol cols="12 mx-auto" sm="6">
-                <UnitIntroduction
-                  v-bind="{ companyName: title, dataPortal, isGenericViewer }"
-                />
-                <UnitFiles
-                  v-bind="{
-                    extensions,
-                    files,
-                    multiple,
-                    allowMissingFiles,
-                    samples: data,
-                    isGenericViewer
-                  }"
-                  @update="onUnitFilesUpdate"
-                />
-                <template v-if="progress">
-                  <BaseProgressCircular class="mr-2" />
-                  <span>Processing files...</span>
-                </template>
-                <template v-else-if="error || success">
-                  <VAlert
-                    :type="error ? 'error' : 'success'"
-                    border="top"
-                    colored-border
-                    max-width="600"
-                    >{{ message }}
-                  </VAlert>
-                </template>
-              </VCol>
-            </div>
+            <VCol cols="12 mx-auto" sm="6" class="tabItem pa-5">
+              <UnitIntroduction
+                v-bind="{ companyName: title, dataPortal, isGenericViewer }"
+              />
+              <UnitFiles
+                v-bind="{
+                  extensions,
+                  files,
+                  multiple,
+                  allowMissingFiles,
+                  samples: data,
+                  isGenericViewer
+                }"
+                @update="onUnitFilesUpdate"
+              />
+              <template v-if="progress">
+                <BaseProgressCircular class="mr-2" />
+                <span>Processing files...</span>
+              </template>
+              <template v-else-if="error || success">
+                <VAlert
+                  :type="error ? 'error' : 'success'"
+                  border="top"
+                  colored-border
+                  max-width="600"
+                  >{{ message }}
+                </VAlert>
+              </template>
+            </VCol>
           </VTabItem>
-          <VTabItem>
-            <div class="tabItem">
+          <VTabItem value="summary">
+            <VCol cols="12 mx-auto" sm="6" class="tabItem">
               <UnitSummary v-bind="{ fileManager }" />
-            </div>
+            </VCol>
           </VTabItem>
           <VTabItem>
             <div class="tabItem">
@@ -75,7 +73,7 @@
             v-for="(defaultViewElements, index) in defaultView"
             :key="index"
           >
-            <div class="tabItem">
+            <VCol cols="12 mx-auto" class="tabItem">
               <UnitQuery
                 v-bind="{
                   defaultViewElements,
@@ -92,10 +90,10 @@
                   db
                 }"
               />
-            </div>
+            </VCol>
           </VTabItem>
           <VTabItem v-if="consentForm">
-            <div class="tabItem">
+            <VCol cols="12 mx-auto" sm="6" class="tabItem">
               <UnitConsentForm
                 v-bind="{
                   consentForm,
@@ -104,7 +102,7 @@
                   showDataExplorer
                 }"
               />
-            </div>
+            </VCol>
           </VTabItem>
         </VTabsItems>
       </VCol>
@@ -308,6 +306,7 @@ export default {
 
       this.progress = false
       this.success = true
+      this.tab = 'summary'
 
       const elapsed = new Date() - start
       this.message = `Successfully processed in ${elapsed / 1000} sec.`
@@ -322,7 +321,7 @@ export default {
 .fixed-tabs-bar {
   position: -webkit-sticky;
   position: sticky;
-  top: 75px;
-  z-index: 200;
+  top: 60px;
+  z-index: 2500;
 }
 </style>

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -264,12 +264,13 @@ export default {
       // Clean vuex state before changing the filemanager
       this.$store.commit('setFileExplorerCurrentItem', {})
 
-      this.fileManager = new FileManager(
+      const fileManager = new FileManager(
         this.preprocessors,
         this.allowMissingFiles,
         fileManagerWorkers
       )
-      await this.fileManager.init(uppyFiles, this.multiple)
+      await fileManager.init(uppyFiles, this.multiple)
+      this.fileManager = fileManager
 
       // Check that the required files are present in the archive
       const missing = this.files

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -1,72 +1,81 @@
 <template>
   <div>
+    <BaseButtonShare color="primary" :outlined="false" />
     <VRow>
-      <VCol cols="12 mx-auto" sm="6">
-        <UnitIntroduction
-          v-bind="{ companyName: title, dataPortal, isGenericViewer }"
-        />
-      </VCol>
-    </VRow>
-    <VRow>
-      <VCol cols="12 mx-auto" sm="6">
-        <UnitFiles
-          v-bind="{
-            extensions,
-            files,
-            multiple,
-            allowMissingFiles,
-            samples: data,
-            isGenericViewer
-          }"
-          @update="onUnitFilesUpdate"
-        />
-        <template v-if="progress">
-          <BaseProgressCircular class="mr-2" />
-          <span>Processing files...</span>
-        </template>
-        <template v-else-if="error || success">
-          <VAlert
-            :type="error ? 'error' : 'success'"
-            border="top"
-            colored-border
-            max-width="600"
-            >{{ message }}
-          </VAlert>
-        </template>
-      </VCol>
-    </VRow>
-    <template v-if="success">
-      <VRow>
-        <VCol>
-          <VTabs
-            v-model="tab"
-            dark
-            background-color="primary"
-            slider-color="secondary"
-            slider-size="4"
-            show-arrows
-            center-active
-            centered
-            fixed-tabs
+      <VCol>
+        <VTabs
+          v-model="tab"
+          dark
+          background-color="primary"
+          slider-color="secondary"
+          slider-size="4"
+          show-arrows
+          center-active
+          centered
+          fixed-tabs
+          class="fixed-tabs-bar"
+        >
+          <VTab>Upload</VTab>
+          <VTab :disabled="!success">Summary</VTab>
+          <VTab :disabled="!success">Files</VTab>
+          <VTab
+            v-for="(el, index) in defaultView"
+            :key="index"
+            :disabled="!success"
           >
-            <VTab>Summary</VTab>
-            <VTab>Files</VTab>
-            <VTab v-for="(el, index) in defaultView" :key="index">
-              {{ el.title }}
-            </VTab>
-            <VTab v-if="consentForm">Share my data</VTab>
-          </VTabs>
-          <VTabsItems v-model="tab">
-            <VTabItem>
+            {{ el.title }}
+          </VTab>
+          <VTab v-if="consentForm" :disabled="!success">Share my data</VTab>
+        </VTabs>
+        <VTabsItems v-model="tab">
+          <VTabItem>
+            <div class="tabItem">
+              <VCol cols="12 mx-auto" sm="6">
+                <UnitIntroduction
+                  v-bind="{ companyName: title, dataPortal, isGenericViewer }"
+                />
+                <UnitFiles
+                  v-bind="{
+                    extensions,
+                    files,
+                    multiple,
+                    allowMissingFiles,
+                    samples: data,
+                    isGenericViewer
+                  }"
+                  @update="onUnitFilesUpdate"
+                />
+                <template v-if="progress">
+                  <BaseProgressCircular class="mr-2" />
+                  <span>Processing files...</span>
+                </template>
+                <template v-else-if="error || success">
+                  <VAlert
+                    :type="error ? 'error' : 'success'"
+                    border="top"
+                    colored-border
+                    max-width="600"
+                    >{{ message }}
+                  </VAlert>
+                </template>
+              </VCol>
+            </div>
+          </VTabItem>
+          <VTabItem>
+            <div class="tabItem">
               <UnitSummary v-bind="{ fileManager }" />
-            </VTabItem>
-            <VTabItem>
+            </div>
+          </VTabItem>
+          <VTabItem>
+            <div class="tabItem">
               <UnitFileExplorer v-bind="{ fileManager }" />
-            </VTabItem>
-            <VTabItem
-              v-for="(defaultViewElements, index) in defaultView"
-              :key="index"
-            >
+            </div>
+          </VTabItem>
+          <VTabItem
+            v-for="(defaultViewElements, index) in defaultView"
+            :key="index"
+          >
+            <div class="tabItem">
               <UnitQuery
                 v-bind="{
                   defaultViewElements,
@@ -83,8 +92,10 @@
                   db
                 }"
               />
-            </VTabItem>
-            <VTabItem v-if="consentForm">
+            </div>
+          </VTabItem>
+          <VTabItem v-if="consentForm">
+            <div class="tabItem">
               <UnitConsentForm
                 v-bind="{
                   consentForm,
@@ -93,11 +104,11 @@
                   showDataExplorer
                 }"
               />
-            </VTabItem>
-          </VTabsItems>
-        </VCol>
-      </VRow>
-    </template>
+            </div>
+          </VTabItem>
+        </VTabsItems>
+      </VCol>
+    </VRow>
   </div>
 </template>
 
@@ -304,3 +315,14 @@ export default {
   }
 }
 </script>
+<style>
+.tabItem {
+  min-height: calc(100vh - 48px);
+}
+.fixed-tabs-bar {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 75px;
+  z-index: 200;
+}
+</style>

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -15,9 +15,9 @@
           fixed-tabs
           class="fixed-tabs-bar"
         >
-          <VTab>Upload</VTab>
+          <VTab>Load your Data</VTab>
           <VTab :disabled="!success" href="#summary">Summary</VTab>
-          <VTab :disabled="!success">Files</VTab>
+          <VTab :disabled="!success" href="#file-explorer">Files</VTab>
           <VTab
             v-for="(el, index) in defaultView"
             :key="index"
@@ -64,7 +64,7 @@
               <UnitSummary v-bind="{ fileManager }" />
             </VCol>
           </VTabItem>
-          <VTabItem>
+          <VTabItem value="file-explorer">
             <div class="tabItem">
               <UnitFileExplorer v-bind="{ fileManager }" />
             </div>
@@ -244,7 +244,7 @@ export default {
   },
   mounted() {
     this.$root.$on('goToFileExplorer', () => {
-      this.tab = 1
+      this.tab = 'file-explorer'
     })
   },
   methods: {

--- a/components/base/button/BaseButton.vue
+++ b/components/base/button/BaseButton.vue
@@ -1,6 +1,11 @@
 <template>
   <VBtn
     :outlined="outlined"
+    :fixed="fixed"
+    :right="right"
+    :bottom="bottom"
+    :top="top"
+    :left="left"
     v-bind="$attrs"
     class="my-2"
     @click="$emit('click', $event)"
@@ -20,6 +25,26 @@ export default {
     text: {
       type: String,
       default: ''
+    },
+    fixed: {
+      type: Boolean,
+      default: false
+    },
+    right: {
+      type: Boolean,
+      default: false
+    },
+    left: {
+      type: Boolean,
+      default: false
+    },
+    top: {
+      type: Boolean,
+      default: false
+    },
+    bottom: {
+      type: Boolean,
+      default: false
     },
     progress: {
       type: Boolean,
@@ -49,3 +74,8 @@ export default {
   }
 }
 </script>
+<style scoped>
+.v-btn {
+  z-index: 4;
+}
+</style>

--- a/components/base/button/BaseButtonShare.vue
+++ b/components/base/button/BaseButtonShare.vue
@@ -3,6 +3,9 @@
     v-if="condition"
     icon="mdiShare"
     :text="buttonText"
+    bottom
+    right
+    fixed
     v-bind="$attrs"
     @click="share"
   />

--- a/components/unit/UnitQuery.vue
+++ b/components/unit/UnitQuery.vue
@@ -195,6 +195,12 @@ export default {
         .map(([glob, _]) => glob)
     }
   },
+  watch: {
+    fileManager() {
+      this.finished = false
+      this.result = null
+    }
+  },
   methods: {
     onUnitResultsUpdate(result) {
       // Postprocessing

--- a/components/unit/UnitQuery.vue
+++ b/components/unit/UnitQuery.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <VCard v-if="defaultViewElements" class="pa-2 mb-6">
+    <VCard v-if="defaultViewElements" class="pa-2 mb-6" flat>
       <VCardTitle class="justify-center">{{
         defaultViewElements.title
       }}</VCardTitle>

--- a/components/unit/UnitSummary.vue
+++ b/components/unit/UnitSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <VCard>
+    <VCard class="pa-2 mb-6" flat>
       <VCardTitle class="justify-center">
         Here's a summary of what we have found
       </VCardTitle>

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -1,66 +1,62 @@
 <template>
   <VForm>
-    <VCard class="pa-2 mb-6">
-      <VCardText>
-        <UnitConsentFormSection
-          v-for="(section, index) in consent"
-          :key="`section-${index}`"
-          v-bind="{
-            section,
-            index,
-            dataCheckboxDisabled,
-            showDataExplorer,
-            fileManager
-          }"
-          @change="updateConsent"
+    <UnitConsentFormSection
+      v-for="(section, index) in consent"
+      :key="`section-${index}`"
+      v-bind="{
+        section,
+        index,
+        dataCheckboxDisabled,
+        showDataExplorer,
+        fileManager
+      }"
+      @change="updateConsent"
+    />
+    <BaseAlert v-if="missingRequired">
+      Some required fields are not filled in.
+    </BaseAlert>
+    <BaseAlert v-if="missingRequiredDataProcessing.length > 0">
+      Some experience required for sending this form has not been ran:
+      {{ missingRequiredDataProcessing.join(', ') }}.
+    </BaseAlert>
+    <BaseAlert v-if="missingRequiredData.length > 0">
+      Some data required for sending this form has not been included:
+      {{ missingRequiredData.join(', ') }}.
+    </BaseAlert>
+    <VRow>
+      <VCol>
+        <VIcon v-if="config.filedrop" class="mr-2" color="#424242"
+          >$vuetify.icons.mdiNumeric1CircleOutline</VIcon
+        >
+        <BaseButton
+          text="Download results"
+          :status="generateStatus"
+          :error="generateError"
+          :progress="generateProgress"
+          :disabled="
+            missingRequired ||
+            missingRequiredDataProcessing.length > 0 ||
+            missingRequiredData.length > 0
+          "
+          @click="generateZIP"
         />
-        <BaseAlert v-if="missingRequired">
-          Some required fields are not filled in.
-        </BaseAlert>
-        <BaseAlert v-if="missingRequiredDataProcessing.length > 0">
-          Some experience required for sending this form has not been ran:
-          {{ missingRequiredDataProcessing.join(', ') }}.
-        </BaseAlert>
-        <BaseAlert v-if="missingRequiredData.length > 0">
-          Some data required for sending this form has not been included:
-          {{ missingRequiredData.join(', ') }}.
-        </BaseAlert>
-        <VRow>
-          <VCol>
-            <VIcon v-if="config.filedrop" class="mr-2" color="#424242"
-              >$vuetify.icons.mdiNumeric1CircleOutline</VIcon
-            >
-            <BaseButton
-              text="Download results"
-              :status="generateStatus"
-              :error="generateError"
-              :progress="generateProgress"
-              :disabled="
-                missingRequired ||
-                missingRequiredDataProcessing.length > 0 ||
-                missingRequiredData.length > 0
-              "
-              @click="generateZIP"
-            />
-            <BaseButtonDownloadData
-              v-show="false"
-              ref="downloadBtn"
-              :data="zipFile"
-              :filename="filename"
-              extension="zip"
-            />
-          </VCol>
-          <VCol v-if="config.filedrop">
-            <VIcon class="mr-2" color="#424242"
-              >$vuetify.icons.mdiNumeric2CircleOutline</VIcon
-            >
-            <a :href="config.filedrop" target="_blank">
-              <BaseButton text="Drop file here" />
-            </a>
-          </VCol>
-        </VRow>
-      </VCardText>
-    </VCard>
+        <BaseButtonDownloadData
+          v-show="false"
+          ref="downloadBtn"
+          :data="zipFile"
+          :filename="filename"
+          extension="zip"
+        />
+      </VCol>
+      <VCol v-if="config.filedrop">
+        <VIcon class="mr-2" color="#424242"
+          >$vuetify.icons.mdiNumeric2CircleOutline</VIcon
+        >
+        <a :href="config.filedrop" target="_blank">
+          <BaseButton text="Drop file here" />
+        </a>
+      </VCol>
+    </VRow>
   </VForm>
 </template>
 

--- a/components/unit/file-explorer/UnitFileExplorer.vue
+++ b/components/unit/file-explorer/UnitFileExplorer.vue
@@ -10,6 +10,7 @@
       class="pa-2 mb-6 explorer"
       :min-height="height"
       height="auto"
+      flat
     >
       <style v-if="isFileLoading">
         :root {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,6 +15,7 @@
         <template v-else> You are online again! </template>
       </VSnackbar>
       <VAlert
+        :value="alert"
         border="right"
         colored-border
         color="primary"
@@ -23,11 +24,13 @@
         dismissible
         max-width="20%"
         class="fixedAlert"
+        transition="slide-x-transition"
         fixed
         bottom
         left
+        @input="alertClosed"
       >
-        Want to know more about the attention economy ?
+        Want to know more about our work ?
         <br />
         <a :href="newsletterURL" target="_blank" rel="noreferrer noopener">
           {{ newsletterMessage }}
@@ -57,7 +60,8 @@ export default {
     return {
       // Display offline message if user opens app when offline
       snackbar: this.$nuxt.isOffline,
-      timeout: 5000
+      timeout: 5000,
+      alert: false
     }
   },
   head() {
@@ -125,6 +129,23 @@ export default {
         statusCode: 500,
         message: 'Web Workers are not supported by this browser'
       })
+    }
+    // Show the newsletter alert once a day
+    if (
+      !this.alert &&
+      (!localStorage.alertNewsletterDismissed ||
+        new Date().getTime() -
+          new Date(localStorage.alertNewsletterDismissed).getTime() >
+          1000 * 3600 * 24) // one day in milliseconds
+    ) {
+      window.setInterval(() => {
+        this.alert = true
+      }, 3000)
+    }
+  },
+  methods: {
+    alertClosed() {
+      localStorage.alertNewsletterDismissed = new Date()
     }
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,7 +27,7 @@
         bottom
         left
       >
-        Wants to know more about BLABLABLA ?
+        Wants to know more about attention economy ?
         <br />
         <a :href="newsletterURL" target="_blank" rel="noreferrer noopener">
           {{ newsletterMessage }}
@@ -50,21 +50,6 @@
 </template>
 
 <script>
-/*
-<VRow>
-          <VCol align="center">
-            <h2>
-              <a
-                :href="newsletterURL"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                {{ newsletterMessage }}
-              </a>
-            </h2>
-          </VCol>
-        </VRow>
-        */
 import { mapGetters } from 'vuex'
 
 export default {
@@ -155,6 +140,6 @@ export default {
 .fixedAlert {
   position: fixed;
   bottom: 0px;
-  z-index: 4;
+  z-index: 2500;
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,7 +27,7 @@
         bottom
         left
       >
-        Wants to know more about attention economy ?
+        Want to know more about the attention economy ?
         <br />
         <a :href="newsletterURL" target="_blank" rel="noreferrer noopener">
           {{ newsletterMessage }}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,8 +2,56 @@
   <VApp>
     <TheAppBar />
     <VMain>
-      <VContainer class="mt-5">
-        <VRow>
+      <Nuxt />
+      <VSnackbar
+        v-model="snackbar"
+        content-class="v-snack__content-online-status"
+        color="info"
+        :timeout="timeout"
+      >
+        <template v-if="$nuxt.isOffline">
+          The app is running in offline mode
+        </template>
+        <template v-else> You are online again! </template>
+      </VSnackbar>
+      <VAlert
+        border="right"
+        colored-border
+        color="primary"
+        elevation="2"
+        close-text="Not now"
+        dismissible
+        max-width="20%"
+        class="fixedAlert"
+        fixed
+        bottom
+        left
+      >
+        Wants to know more about BLABLABLA ?
+        <br />
+        <a :href="newsletterURL" target="_blank" rel="noreferrer noopener">
+          {{ newsletterMessage }}
+        </a>
+      </VAlert>
+    </VMain>
+    <VFooter app absolute color="primary">
+      <div class="lighten-2 py-2 ma-auto white--text" align="center">
+        Educational material developed by
+        <a href="https://hestia.ai" target="_blank" style="color: white"
+          >Hestia.ai</a
+        >
+        <br />Currently in development | Subscribe to our
+        <a :href="newsletterURL" target="_blank" style="color: white">
+          Newsletter
+        </a>
+      </div>
+    </VFooter>
+  </VApp>
+</template>
+
+<script>
+/*
+<VRow>
           <VCol align="center">
             <h2>
               <a
@@ -16,33 +64,7 @@
             </h2>
           </VCol>
         </VRow>
-        <Nuxt />
-        <VSnackbar
-          v-model="snackbar"
-          content-class="v-snack__content-online-status"
-          color="info"
-          :timeout="timeout"
-        >
-          <template v-if="$nuxt.isOffline">
-            The app is running in offline mode
-          </template>
-          <template v-else> You are online again! </template>
-        </VSnackbar>
-      </VContainer>
-    </VMain>
-    <VFooter app absolute color="primary">
-      <div class="lighten-2 py-2 ma-auto white--text" align="center">
-        Educational material developed by
-        <a href="https://hestia.ai" target="_blank" style="color: white"
-          >Hestia.ai</a
-        >
-        <br />Currently in development
-      </div>
-    </VFooter>
-  </VApp>
-</template>
-
-<script>
+        */
 import { mapGetters } from 'vuex'
 
 export default {
@@ -128,4 +150,11 @@ export default {
 
 .v-snack__content.v-snack__content-online-status
   text-align: center
+</style>
+<style scoped>
+.fixedAlert {
+  position: fixed;
+  bottom: 0px;
+  z-index: 4;
+}
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -40,9 +40,9 @@
         <a href="https://hestia.ai" target="_blank" style="color: white"
           >Hestia.ai</a
         >
-        <br />Currently in development | Subscribe to our
+        <br />Currently in development |
         <a :href="newsletterURL" target="_blank" style="color: white">
-          Newsletter
+          {{ newsletterMessage }}
         </a>
       </div>
     </VFooter>

--- a/pages/_key.vue
+++ b/pages/_key.vue
@@ -1,7 +1,10 @@
 <template>
-  <!-- avoid double margin: we're already in a container -->
-  <VContainer class="ma-n3">
-    <VRow class="no-gutters">
+  <TheDataExperience v-if="m.rest" v-bind="m.rest" />
+</template>
+
+<script>
+/*
+<VRow class="no-gutters">
       <VCol>
         <div class="d-flex">
           <VImg max-width="50" :src="m.icon" :lazy-src="m.icon" contain />
@@ -14,11 +17,7 @@
         </p>
       </VCol>
     </VRow>
-    <TheDataExperience v-if="m.rest" v-bind="m.rest" />
-  </VContainer>
-</template>
-
-<script>
+    */
 import { mapState, mapGetters } from 'vuex'
 
 export default {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,7 @@
 <template>
-  <TheExperienceMenu :cards="$vuetify.breakpoint.smAndUp" />
+  <VContainer>
+    <TheExperienceMenu :cards="$vuetify.breakpoint.smAndUp" />
+  </VContainer>
 </template>
 
 <style>

--- a/vuetify.options.js
+++ b/vuetify.options.js
@@ -1,5 +1,6 @@
 import {
   mdiAlert,
+  mdiAutorenew,
   mdiCheckboxBlankOutline,
   mdiCheckCircle,
   mdiChevronLeft,
@@ -10,6 +11,7 @@ import {
   mdiDownload,
   mdiExport,
   mdiFileSearch,
+  mdiFilter,
   mdiHome,
   mdiMagnify,
   mdiMinus,
@@ -19,8 +21,7 @@ import {
   mdiTuneVariant,
   mdiShare,
   mdiStepForward,
-  mdiTwitter,
-  mdiFilter
+  mdiTwitter
 } from '@mdi/js'
 
 export default {
@@ -28,6 +29,7 @@ export default {
     iconfont: 'mdiSvg',
     values: {
       mdiAlert,
+      mdiAutorenew,
       mdiCheckboxBlankOutline,
       mdiCheckCircle,
       mdiChevronLeft,
@@ -38,6 +40,7 @@ export default {
       mdiDownload,
       mdiExport,
       mdiFileSearch,
+      mdiFilter,
       mdiHome,
       mdiMagnify,
       mdiMinus,
@@ -47,8 +50,7 @@ export default {
       mdiTuneVariant,
       mdiShare,
       mdiStepForward,
-      mdiTwitter,
-      mdiFilter
+      mdiTwitter
     }
   },
   theme: {


### PR DESCRIPTION
This PR is related to #511 and apply the following changes: 
- make the whole experience page as tabs
- remove the shadow effect from the sub-experience cards
- display the newsletter as a disposable alert (and in the footer)
- make the share button at a fixed position. 
- Add title experiences in the app top bar

Demo: 
![image](https://user-images.githubusercontent.com/17878016/150514927-7e5e7714-4788-47cf-bcac-0afd8d9867af.png)

A lot can be done to improve the UI/UX, this is just a first step.
Now that the size of the sub-experience containers has changed, we need to improve the rendering of each sub-experience, but this could be done in separate issues. 
