### PR TITLE
feat: add text filtering for targeting criteria and company in Twitter overview

### DIFF
--- a/components/chart/view/ChartViewOverviewTwitter.vue
+++ b/components/chart/view/ChartViewOverviewTwitter.vue
@@ -6,29 +6,33 @@
           <VCol cols="12" sm="8">
             <div id="volume-chart">
               <strong>Number of ads over time</strong>
-              <a class="reset" style="display: none">reset</a>
               <p class="filters">
                 <span>
                   Current filter:
                   <span class="filter"></span>
                 </span>
+                <a class="reset" style="display: none">reset</a>
               </p>
             </div>
             <div :id="'range-chart' + graphId" class="range-chart">
               <p class="muted pull-right" style="margin-right: 15px">
-                select a time range to zoom in
+                select a <strong>time range</strong> to zoom in
               </p>
             </div>
           </VCol>
           <VCol cols="12" sm="4">
             <div id="company-chart">
-              <strong>Top 10 advertisers</strong>
-              <a class="reset" style="display: none">reset</a>
+              <div style="display: flex">
+                <strong>Top 10 advertisers</strong>
+                <VSpacer />
+                <div id="company-search"></div>
+              </div>
               <p class="filters">
                 <span>
                   Current filter:
                   <span class="filter"></span>
                 </span>
+                <a class="reset" style="display: none">reset</a>
               </p>
             </div>
           </VCol>
@@ -37,36 +41,44 @@
           <VCol cols="12" sm="4">
             <div id="engagement-chart">
               <strong>Interactions with ads (clicks, video views)</strong>
-              <a class="reset" style="display: none">reset</a>
               <p class="filters">
                 <span>
                   Current filter:
                   <span class="filter"></span>
                 </span>
+                <a class="reset" style="display: none">reset</a>
               </p>
             </div>
           </VCol>
           <VCol cols="12" sm="4">
             <div id="type-chart">
-              <strong>Type of targeting</strong>
-              <a class="reset" style="display: none">reset</a>
+              <div style="display: flex">
+                <strong>Type of targeting</strong>
+                <VSpacer />
+                <div id="type-search"></div>
+              </div>
               <p class="filters">
                 <span>
                   Current filter:
                   <span class="filter"></span>
                 </span>
+                <a class="reset" style="display: none">reset</a>
               </p>
             </div>
           </VCol>
           <VCol cols="12" sm="4">
             <div id="value-chart">
-              <strong>Targeting criteria</strong>
-              <a class="reset" style="display: none">reset</a>
+              <div style="display: flex">
+                <strong>Targeting criteria</strong>
+                <VSpacer />
+                <div id="value-search"></div>
+              </div>
               <p class="filters">
                 <span>
                   Current filter:
                   <span class="filter"></span>
                 </span>
+                <a class="reset" style="display: none">reset</a>
               </p>
             </div>
           </VCol>
@@ -108,7 +120,11 @@ export default {
         { text: 'Company', value: 'companyName' },
         { text: 'Date', value: 'date' },
         { text: 'Promoted Tweet', value: 'url' },
-        { text: 'Engagement', value: 'engagement' },
+        {
+          text: 'Engagement',
+          value: 'engagement',
+          formatter: d => (d === 0 ? 'No' : 'Yes')
+        },
         { text: 'Targeting Criteria', value: 'count' }
       ],
       results: []
@@ -133,26 +149,29 @@ export default {
       const engagementChart = new dc.PieChart('#engagement-chart')
       const typeChart = new dc.RowChart('#type-chart')
       const valueChart = new dc.RowChart('#value-chart')
+      const companySearch = new dc.TextFilterWidget('#company-search')
+      const typeSearch = new dc.TextFilterWidget('#type-search')
+      const valueSearch = new dc.TextFilterWidget('#value-search')
 
       // Bind reset filters links
-      d3.select('#volume-chart a.reset').on('click', function () {
+      d3.select('#volume-chart p a.reset').on('click', function () {
         rangeChart.filterAll()
         volumeChart.filterAll()
         dc.redrawAll()
       })
-      d3.select('#company-chart a.reset').on('click', function () {
+      d3.select('#company-chart p a.reset').on('click', function () {
         companyChart.filterAll()
         dc.redrawAll()
       })
-      d3.select('#engagement-chart a.reset').on('click', function () {
+      d3.select('#engagement-chart p a.reset').on('click', function () {
         engagementChart.filterAll()
         dc.redrawAll()
       })
-      d3.select('#type-chart a.reset').on('click', function () {
+      d3.select('#type-chart p a.reset').on('click', function () {
         typeChart.filterAll()
         dc.redrawAll()
       })
-      d3.select('#value-chart a.reset').on('click', function () {
+      d3.select('#value-chart p a.reset').on('click', function () {
         valueChart.filterAll()
         dc.redrawAll()
       })
@@ -189,7 +208,9 @@ export default {
       )
       const targetingTypeDimension = ndx.dimension(d => d.targetingType)
       const targetingValueDimension = ndx.dimension(d => d.targetingValue)
-
+      companySearch.dimension(ndx.dimension(d => d.companyName.toLowerCase()))
+      typeSearch.dimension(ndx.dimension(d => d.targetingType.toLowerCase()))
+      valueSearch.dimension(ndx.dimension(d => d.targetingValue.toLowerCase()))
       // custom reduce function for grouping by ad and not targeting criteria
       const init = () => ({
         // initial
@@ -261,7 +282,7 @@ export default {
         .elasticX(false)
         .elasticY(true)
         .xyTipsOn(true)
-        .mouseZoomable(true)
+        .mouseZoomable(false)
         .rangeChart(rangeChart)
         .renderHorizontalGridLines(false)
         .renderDataPoints({
@@ -454,5 +475,12 @@ export default {
 ::v-deep p.filters {
   font-size: 0.8rem;
   font-style: italic;
+}
+::v-deep .dc-text-filter-input {
+  font-family: inherit;
+  border: 0;
+  border-bottom: 1px solid gray;
+  outline: 0;
+  background: transparent;
 }
 </style>

--- a/components/unit/filterable-table/UnitFilterableTable.vue
+++ b/components/unit/filterable-table/UnitFilterableTable.vue
@@ -47,7 +47,7 @@
                 dense
                 class="pa-4"
                 label="Search ..."
-                :items="columnValues(header.value)"
+                :items="columnValues(header)"
                 :menu-props="{ closeOnClick: true }"
               >
                 <template #selection="{ item, index }">
@@ -76,20 +76,10 @@
           <a target="_blank" rel="noreferrer noopener" :href="value"> Link </a>
         </template>
         <template
-          v-for="header in headers.filter(
-            h => h.value !== 'url' && !header.hasOwnProperty('formatter')
-          )"
+          v-for="header in headers.filter(h => h.value !== 'url')"
           #[`item.${header.value}`]="slotProps"
         >
           {{ formatItemAsString(slotProps) }}
-        </template>
-        <template
-          v-for="header in headers.filter(header =>
-            header.hasOwnProperty('formatter')
-          )"
-          #[`item.${header.value}`]
-        >
-          {{ header.formatter(value) }}
         </template>
       </VDataTable>
       <BaseButton
@@ -148,8 +138,6 @@ export default {
       return headers.map(h => ({
         ...h,
         align: 'left',
-        // class: 'header',
-        // width: 6 + 0.35 * h.text.length + 'rem',
         sortable: true
       }))
     },
@@ -175,6 +163,10 @@ export default {
   methods: {
     formatItemAsString(itemProps) {
       const { header, value } = itemProps
+      // eslint-disable-next-line no-prototype-builtins
+      if (header.hasOwnProperty('formatter')) {
+        return header.formatter(value)
+      }
       if (Array.isArray(value)) {
         return formatArray(value)
       }
@@ -207,8 +199,10 @@ export default {
         this.status = true
       }
     },
-    columnValues(val) {
-      return this.items.map(d => d[val])
+    columnValues(header) {
+      return this.items.map(d =>
+        this.formatItemAsString({ header, value: d[header.value] })
+      )
     },
     onItemsUpdate() {
       // wait until the DOM has completely updated

--- a/components/unit/filterable-table/UnitFilterableTable.vue
+++ b/components/unit/filterable-table/UnitFilterableTable.vue
@@ -76,10 +76,20 @@
           <a target="_blank" rel="noreferrer noopener" :href="value"> Link </a>
         </template>
         <template
-          v-for="header in headers.filter(h => h.value !== 'url')"
+          v-for="header in headers.filter(
+            h => h.value !== 'url' && !header.hasOwnProperty('formatter')
+          )"
           #[`item.${header.value}`]="slotProps"
         >
           {{ formatItemAsString(slotProps) }}
+        </template>
+        <template
+          v-for="header in headers.filter(header =>
+            header.hasOwnProperty('formatter')
+          )"
+          #[`item.${header.value}`]
+        >
+          {{ header.formatter(value) }}
         </template>
       </VDataTable>
       <BaseButton


### PR DESCRIPTION
This PR is related to #514.
To improve the graph's ability to explore different combinations of targeting criteria against advertisers, I have added a search function in the Twitter overview for targeting criteria, advertiser and targeting value. 

![image](https://user-images.githubusercontent.com/17878016/150550302-c364d45f-3392-4d64-9668-cc95b4f55702.png)

This way, a user can, for example, search for any targeting value that are not already displayed on the top 10 and see which advertiser uses that targeting criteria and vice versa. See the example below: 
![image](https://user-images.githubusercontent.com/17878016/150550868-13c90a87-6a56-49c3-a4a2-b46f53ab0ae1.png)

In addition, I have added to the table the ability to attach a formatter for each column, this is used in TwitterOverview to convert engagement values 0 and 1 to 'Yes' or 'No'.
