### PR TITLE
fix: remove all restrictions on file upload

### DIFF
--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -228,10 +228,11 @@ export default {
 
       const fileManager = new FileManager(
         this.preprocessors,
-        fileManagerWorkers
+        fileManagerWorkers,
+        this.files
       )
       try {
-        await fileManager.init(uppyFiles, true, this.files)
+        await fileManager.init(uppyFiles, true)
       } catch (e) {
         this.handleError(e)
         return

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -31,16 +31,13 @@
           <VTabItem>
             <VCol cols="12 mx-auto" sm="6" class="tabItem pa-5">
               <UnitIntroduction
-                v-bind="{ companyName: title, dataPortal, isGenericViewer }"
+                v-bind="{ companyName: title, dataPortal }"
                 ref="unit-introduction"
               />
               <UnitFiles
                 v-bind="{
-                  extensions,
                   files,
-                  multiple,
-                  samples: data,
-                  isGenericViewer
+                  samples: data
                 }"
                 ref="unit-files"
                 @update="onUnitFilesUpdate"
@@ -99,8 +96,7 @@
                 v-bind="{
                   consentForm,
                   defaultView,
-                  fileManager,
-                  showDataExplorer
+                  fileManager
                 }"
               />
             </VCol>
@@ -112,7 +108,6 @@
 </template>
 
 <script>
-import { validExtensions } from '~/manifests/utils'
 import FileManager from '~/utils/file-manager'
 import fileManagerWorkers from '~/utils/file-manager-workers'
 import parseYarrrml from '~/utils/parse-yarrrml'
@@ -133,16 +128,6 @@ export default {
       type: Array,
       default: () => []
     },
-    ext: {
-      type: String,
-      required: true,
-      validator(val) {
-        return (
-          val === 'all' ||
-          val.split(',').every(v => validExtensions.includes(v))
-        )
-      }
-    },
     files: {
       type: Object,
       default: () => {}
@@ -150,10 +135,6 @@ export default {
     defaultView: {
       type: Array,
       default: () => []
-    },
-    multiple: {
-      type: Boolean,
-      default: false
     },
     preprocessors: {
       type: Object,
@@ -166,14 +147,6 @@ export default {
     customPipelines: {
       type: Object,
       default: undefined
-    },
-    isGenericViewer: {
-      type: Boolean,
-      default: false
-    },
-    showDataExplorer: {
-      type: Boolean,
-      default: true
     },
     sparql: {
       type: Object,
@@ -229,14 +202,6 @@ export default {
         }
       }
       return null
-    },
-    extensions() {
-      return this.ext === 'all'
-        ? []
-        : this.ext
-            .replace(/\s/g, '')
-            .split(',')
-            .map(ext => `.${ext}`)
     }
   },
   mounted() {
@@ -266,7 +231,7 @@ export default {
         fileManagerWorkers
       )
       try {
-        await fileManager.init(uppyFiles, this.multiple, this.files)
+        await fileManager.init(uppyFiles, true, this.files)
       } catch (e) {
         this.handleError(e)
         return

--- a/components/TheDataExperience.vue
+++ b/components/TheDataExperience.vue
@@ -232,7 +232,7 @@ export default {
         this.files
       )
       try {
-        await fileManager.init(uppyFiles, true)
+        await fileManager.init(uppyFiles)
       } catch (e) {
         this.handleError(e)
         return

--- a/components/unit/UnitIntroduction.vue
+++ b/components/unit/UnitIntroduction.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1>Analyze your private data</h1>
-    <p v-if="isGenericViewer" class="body-1">
+    <p v-if="$route.params.key === 'explorer'" class="body-1">
       Explore the structure and contents of any file.
     </p>
     <p v-else class="body-1">
@@ -33,8 +33,7 @@ export default {
     dataPortal: {
       type: String,
       default: ''
-    },
-    isGenericViewer: Boolean
+    }
   }
 }
 </script>

--- a/components/unit/UnitQuery.vue
+++ b/components/unit/UnitQuery.vue
@@ -25,6 +25,7 @@
           <UnitFilesDialog
             v-else-if="fileGlobs.length > 0"
             :file-globs="fileGlobs"
+            :file-manager="fileManager"
         /></VCol>
       </VRow>
 

--- a/components/unit/consent-form/UnitConsentForm.vue
+++ b/components/unit/consent-form/UnitConsentForm.vue
@@ -7,7 +7,6 @@
         section,
         index,
         dataCheckboxDisabled,
-        showDataExplorer,
         fileManager
       }"
       @change="updateConsent"
@@ -83,10 +82,6 @@ export default {
     fileManager: {
       type: FileManager,
       required: true
-    },
-    showDataExplorer: {
-      type: Boolean,
-      default: true
     }
   },
   data() {

--- a/components/unit/consent-form/UnitConsentFormSection.vue
+++ b/components/unit/consent-form/UnitConsentFormSection.vue
@@ -138,10 +138,6 @@ export default {
       type: Object,
       default: () => {}
     },
-    showDataExplorer: {
-      type: Boolean,
-      default: true
-    },
     fileManager: {
       type: FileManager,
       required: true

--- a/components/unit/files/UnitFiles.vue
+++ b/components/unit/files/UnitFiles.vue
@@ -13,8 +13,6 @@
       class="mb-4"
     />
 
-    <div class="caption my-2">{{ extensionsMessage }}</div>
-
     <div ref="dashboard" />
 
     <BaseButton
@@ -46,32 +44,19 @@ async function fetchSampleFile({ path, filename }) {
 export default {
   name: 'UnitFiles',
   props: {
-    extensions: {
-      type: Array,
-      required: true
-    },
     files: {
       type: Object,
       required: true
     },
-    multiple: {
-      type: Boolean,
-      default: false
-    },
     samples: {
       type: Array,
       default: () => []
-    },
-    isGenericViewer: Boolean
+    }
   },
   data() {
     const config = {
       debug: false,
-      allowMultipleUploads: this.multiple,
-      restrictions: {
-        maxNumberOfFiles: this.multiple ? null : 1,
-        allowedFileTypes: this.extensions.length > 0 ? this.extensions : null
-      }
+      allowMultipleUploads: true
     }
     return {
       uppy: new Uppy(config),
@@ -80,8 +65,7 @@ export default {
       status: false,
       error: false,
       progress: false,
-      filesToExtract: this.files,
-      cachedResult: null
+      filesToExtract: this.files
     }
   },
   computed: {
@@ -90,12 +74,6 @@ export default {
     },
     isPlayground() {
       return this.key === 'playground'
-    },
-    extensionsMessage() {
-      const exts = this.extensions.join(', ')
-      return `${this.multiple ? 'Multiple files' : 'One file'} allowed (${
-        exts.length > 0 ? exts : 'any extension'
-      })`
     },
     disabled() {
       return this.filesEmpty

--- a/components/unit/files/UnitFilesDialog.vue
+++ b/components/unit/files/UnitFilesDialog.vue
@@ -18,10 +18,23 @@
           <p v-if="main" class="mt-4">Files used in the experiences:</p>
           <p v-else class="mt-4">Files required:</p>
           <ul>
-            <li v-for="file in fileGlobs" :key="file">
-              {{ file }}
+            <li v-for="glob in fileGlobs" :key="glob">
+              {{ glob }}
             </li>
           </ul>
+          <template v-if="!main && fileManager">
+            <p class="mt-4">Files found:</p>
+            <ul>
+              <template v-for="glob in fileGlobs">
+                <li
+                  v-for="file in fileManager.findMatchingFilePaths(glob)"
+                  :key="file"
+                >
+                  {{ file }}
+                </li>
+              </template>
+            </ul>
+          </template>
         </template>
         <p v-else class="mt-4">
           No specific files are used in these experiences.
@@ -46,6 +59,8 @@
 </template>
 
 <script>
+import FileManager from '~/utils/file-manager'
+
 export default {
   props: {
     fileGlobs: {
@@ -55,6 +70,10 @@ export default {
     main: {
       type: Boolean,
       default: false
+    },
+    fileManager: {
+      type: FileManager,
+      default: null
     }
   },
   data() {

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -34,22 +34,11 @@ Note: All files and folders should match the following regular expression: [`^(?
     */
   "dataPortal": "https://example.com/data-portal",
   /**
-    * Comma-separated list of allowed file extensions (required)
-    * @type String
-    */
-  "ext": "json,csv,zip",
-  /**
     * The list of specific files that are used in the experiences. They are defined by an ID and a glob.
     * In the experiences, we should always refer to the ID of the files.
     * @type Object
     */
   "files": {"impressions": "**/data/ad-impressions.js"},
-  /**
-    * Can the user input multiple files?
-    * @type Boolean
-    * @default false
-    */
-  "multiple": false,
   /**
     * Reference to a preprocessor (optional, see preprocessors.js)
     * @type String

--- a/manifests/experiences/amazon/amazon.json
+++ b/manifests/experiences/amazon/amazon.json
@@ -1,7 +1,6 @@
 {
   "title": "Amazon",
   "icon": "amazon.png",
-  "ext": "json",
   "data": [],
   "disabled": true
 }

--- a/manifests/experiences/apple/apple.json
+++ b/manifests/experiences/apple/apple.json
@@ -1,10 +1,6 @@
 {
   "title": "Apple",
   "icon": "apple.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/bookbeat/bookbeat.json
+++ b/manifests/experiences/bookbeat/bookbeat.json
@@ -1,10 +1,6 @@
 {
   "title": "BookBeat",
   "icon": "bookbeat.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/demdex/demdex.json
+++ b/manifests/experiences/demdex/demdex.json
@@ -1,10 +1,6 @@
 {
   "title": "Demdex",
   "icon": "demdex.jpg",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/explorer/explorer.json
+++ b/manifests/experiences/explorer/explorer.json
@@ -2,10 +2,6 @@
   "title": "Other",
   "subtitle": "Explore data from anywhere!",
   "icon": "clipboard-search-outline.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/facebook/__tests__/database.test.js
+++ b/manifests/experiences/facebook/__tests__/database.test.js
@@ -33,7 +33,7 @@ async function getDatabase(mockedFiles) {
     null,
     manifest.files
   )
-  await fileManager.init(mockedFiles, true)
+  await fileManager.init(mockedFiles)
   db = await databaseBuilder(fileManager)
 }
 

--- a/manifests/experiences/facebook/__tests__/database.test.js
+++ b/manifests/experiences/facebook/__tests__/database.test.js
@@ -28,8 +28,12 @@ function runQuery(sqlFilePath) {
 }
 
 async function getDatabase(mockedFiles) {
-  const fileManager = new FileManager(manifest.preprocessors)
-  await fileManager.init(mockedFiles, true, manifest.files)
+  const fileManager = new FileManager(
+    manifest.preprocessors,
+    null,
+    manifest.files
+  )
+  await fileManager.init(mockedFiles, true)
   db = await databaseBuilder(fileManager)
 }
 

--- a/manifests/experiences/facebook/database.js
+++ b/manifests/experiences/facebook/database.js
@@ -14,7 +14,9 @@ export default async function databaseBuilder(fileManager) {
     ['timestamp', 'INTEGER']
   ])
   const advertisersInteractedWithFile = JSON.parse(
-    await fileManager.getPreprocessedTextFromId('advertisers-interacted')
+    (
+      await fileManager.getPreprocessedTextFromId('advertisers-interacted')
+    )[0] ?? null
   )
   const advertisersInteracted =
     JSONPath({
@@ -35,7 +37,9 @@ export default async function databaseBuilder(fileManager) {
   /// Advertisers who purchased your contact ////////////////////////////////////////////////////////////////////////////////
   db.create('advertisersContactInformation', [['name', 'TEXT']])
   const advertisersContactInformationFile = JSON.parse(
-    await fileManager.getPreprocessedTextFromId('advertisers-contact-list')
+    (
+      await fileManager.getPreprocessedTextFromId('advertisers-contact-list')
+    )[0] ?? null
   )
   const advertisersContact =
     JSONPath({
@@ -60,7 +64,8 @@ export default async function databaseBuilder(fileManager) {
   ])
 
   const offFacebookActivityFile = JSON.parse(
-    await fileManager.getPreprocessedTextFromId('off-facebook-activity')
+    (await fileManager.getPreprocessedTextFromId('off-facebook-activity'))[0] ??
+      null
   )
 
   const offFacebookActivityJSON =
@@ -91,13 +96,14 @@ export default async function databaseBuilder(fileManager) {
     ['id', 'INTEGER'],
     ['name', 'TEXT']
   ])
-  const inferredInterestsFile =
-    JSON.parse(await fileManager.getPreprocessedTextFromId('ads-interests')) ??
-    []
-  const inferredInterestsJSON = JSONPath({
-    path: '$.topics_v2[*]',
-    json: inferredInterestsFile
-  })
+  const inferredInterestsFile = JSON.parse(
+    (await fileManager.getPreprocessedTextFromId('ads-interests'))[0] ?? null
+  )
+  const inferredInterestsJSON =
+    JSONPath({
+      path: '$.topics_v2[*]',
+      json: inferredInterestsFile
+    }) ?? []
   const inferredInterestsItems = []
   inferredInterestsJSON.forEach((v, i) => {
     inferredInterestsItems.push({

--- a/manifests/experiences/facebook/facebook.json
+++ b/manifests/experiences/facebook/facebook.json
@@ -2,7 +2,6 @@
   "title": "Facebook",
   "icon": "facebk.png",
   "dataPortal": "https://www.facebook.com/help/212802592074644",
-  "ext": "zip",
   "data": [],
   "files": {
     "advertisers-interacted": "**/ads_information/advertisers_you've_interacted_with.json",

--- a/manifests/experiences/finnair/finnair.json
+++ b/manifests/experiences/finnair/finnair.json
@@ -1,10 +1,6 @@
 {
   "title": "FinnAir",
   "icon": "finnair.jpg",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/full-contact/full-contact.json
+++ b/manifests/experiences/full-contact/full-contact.json
@@ -1,10 +1,6 @@
 {
   "title": "Full Contact",
   "icon": "full-contact.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/gigantti/gigantti.json
+++ b/manifests/experiences/gigantti/gigantti.json
@@ -1,10 +1,6 @@
 {
   "title": "Gigantti",
   "icon": "gigantti.jpg",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/google/google.json
+++ b/manifests/experiences/google/google.json
@@ -2,10 +2,6 @@
   "title": "Google",
   "icon": "google.png",
   "dataPortal": "https://takeout.google.com/settings/takeout",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "data": [],
   "timedObservationsViewer": {
     "fileMatchers": [

--- a/manifests/experiences/helsingin-sanomat/helsingin-sanomat.json
+++ b/manifests/experiences/helsingin-sanomat/helsingin-sanomat.json
@@ -1,10 +1,6 @@
 {
   "title": "Helsingin Sanomat",
   "icon": "helsingin-sanomat.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/hsl/hsl.json
+++ b/manifests/experiences/hsl/hsl.json
@@ -1,10 +1,6 @@
 {
   "title": "HSL",
   "icon": "hsl.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/k-ryhma/k-ryhma.json
+++ b/manifests/experiences/k-ryhma/k-ryhma.json
@@ -1,10 +1,6 @@
 {
   "title": "K-Ryhmä",
   "icon": "k-ryhma.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/lime/lime.json
+++ b/manifests/experiences/lime/lime.json
@@ -1,10 +1,6 @@
 {
   "title": "Lime",
   "icon": "lime.jpg",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/linkedin/linkedin.json
+++ b/manifests/experiences/linkedin/linkedin.json
@@ -1,10 +1,6 @@
 {
   "title": "LinkedIn",
   "icon": "linkedin.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/netflix/netflix.json
+++ b/manifests/experiences/netflix/netflix.json
@@ -1,14 +1,10 @@
 {
   "title": "Netflix",
   "icon": "netflix.png",
-  "ext": "zip",
   "files": {
     "viewing-activity": "**/CONTENT_INTERACTION/ViewingActivity.csv",
     "messages-by-netflix": "**/MESSAGES/MessagesSentByNetflix.csv"
   },
-  "multiple": false,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "watchOverview",

--- a/manifests/experiences/netflix/pipeline.js
+++ b/manifests/experiences/netflix/pipeline.js
@@ -1,11 +1,11 @@
 import { genericDateViewer } from '~/manifests/generic-pipelines'
 
 async function viewingData({ fileManager }) {
-  return await fileManager.getCsvItemsFromId('viewing-activity')
+  return (await fileManager.getCsvItemsFromId('viewing-activity'))[0]
 }
 
 async function messagesData({ fileManager }) {
-  return await fileManager.getCsvItemsFromId('messages-by-netflix')
+  return (await fileManager.getCsvItemsFromId('messages-by-netflix'))[0]
   /*
   const result = await fileManager.getCsvItems(
     'MESSAGES/MessagesSentByNetflix.csv'

--- a/manifests/experiences/s-ryhma/s-ryhma.json
+++ b/manifests/experiences/s-ryhma/s-ryhma.json
@@ -1,10 +1,6 @@
 {
   "title": "S-Ryhmä",
   "icon": "s-ryhma.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/sbb/sbb.json
+++ b/manifests/experiences/sbb/sbb.json
@@ -1,10 +1,6 @@
 {
   "title": "SBB/CFF",
   "icon": "sbb.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/signal/signal.json
+++ b/manifests/experiences/signal/signal.json
@@ -1,10 +1,6 @@
 {
   "title": "Signal",
   "icon": "signal.svg",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/spotify/spotify.json
+++ b/manifests/experiences/spotify/spotify.json
@@ -1,10 +1,6 @@
 {
   "title": "Spotify",
   "icon": "spotify.png",
-  "ext": "all",
-  "multiple": false,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/tinder/__tests__/database.test.js
+++ b/manifests/experiences/tinder/__tests__/database.test.js
@@ -27,7 +27,7 @@ async function getDatabase(mockedFiles) {
     null,
     manifest.files
   )
-  await fileManager.init(mockedFiles, true)
+  await fileManager.init(mockedFiles)
   db = await databaseBuilder(fileManager)
 }
 

--- a/manifests/experiences/tinder/__tests__/database.test.js
+++ b/manifests/experiences/tinder/__tests__/database.test.js
@@ -22,8 +22,12 @@ function runQuery(sqlFilePath) {
 }
 
 async function getDatabase(mockedFiles) {
-  const fileManager = new FileManager(manifest.preprocessors)
-  await fileManager.init(mockedFiles, true, manifest.files)
+  const fileManager = new FileManager(
+    manifest.preprocessors,
+    null,
+    manifest.files
+  )
+  await fileManager.init(mockedFiles, true)
   db = await databaseBuilder(fileManager)
 }
 

--- a/manifests/experiences/tinder/database.js
+++ b/manifests/experiences/tinder/database.js
@@ -9,7 +9,7 @@ export default async function databaseBuilder(fileManager) {
 
   // There should be only one json file in a tinder export
   const TinderFile = JSON.parse(
-    await fileManager.getPreprocessedTextFromId('tinder')
+    (await fileManager.getPreprocessedTextFromId('tinder'))[0] ?? null
   )
 
   /// Likes ////////////////////
@@ -18,10 +18,11 @@ export default async function databaseBuilder(fileManager) {
     ['date', 'TEXT'],
     ['amount', 'INTEGER']
   ])
-  const likesJSON = JSONPath({
-    path: '$.Usage.swipes_likes[*]',
-    json: TinderFile
-  })
+  const likesJSON =
+    JSONPath({
+      path: '$.Usage.swipes_likes[*]',
+      json: TinderFile
+    }) ?? []
   const likesItems = []
   likesJSON.forEach((v, i) => {
     likesItems.push({

--- a/manifests/experiences/tinder/database.js
+++ b/manifests/experiences/tinder/database.js
@@ -7,15 +7,17 @@ export default async function databaseBuilder(fileManager) {
   const db = new DB()
   await db.init()
 
+  // There should be only one json file in a tinder export
+  const TinderFile = JSON.parse(
+    await fileManager.getPreprocessedTextFromId('tinder')
+  )
+
   /// Likes ////////////////////
   db.create('TinderDB', [
     ['action', 'TEXT'],
     ['date', 'TEXT'],
     ['amount', 'INTEGER']
   ])
-  const TinderFile = JSON.parse(
-    await fileManager.getPreprocessedTextFromId('tinder')
-  )
   const likesJSON = JSONPath({
     path: '$.Usage.swipes_likes[*]',
     json: TinderFile

--- a/manifests/experiences/tinder/tinder.json
+++ b/manifests/experiences/tinder/tinder.json
@@ -2,10 +2,11 @@
   "title": "Tinder",
   "icon": "tinder.png",
   "dataPortal": "https://account.gotinder.com/data",
-  "ext": "json",
+  "ext": "all",
+  "multiple": true,
   "data": ["tinder-synthetic.json"],
   "files": {
-    "tinder": "input.json"
+    "tinder": "**/*.json"
   },
   "preprocessors": {
     "input.json": "tinder"

--- a/manifests/experiences/tinder/tinder.json
+++ b/manifests/experiences/tinder/tinder.json
@@ -2,14 +2,12 @@
   "title": "Tinder",
   "icon": "tinder.png",
   "dataPortal": "https://account.gotinder.com/data",
-  "ext": "all",
-  "multiple": true,
   "data": ["tinder-synthetic.json"],
   "files": {
     "tinder": "**/*.json"
   },
   "preprocessors": {
-    "input.json": "tinder"
+    "**/*.json": "tinder"
   },
   "collaborator": {
     "title": "The Dating Privacy Collective",

--- a/manifests/experiences/tracker-control/pipeline.js
+++ b/manifests/experiences/tracker-control/pipeline.js
@@ -1,7 +1,7 @@
 import { setsEqual } from '~/utils/utils'
 
 async function trackerControl({ fileManager }) {
-  const tcFiles = await fileManager.getCsvItemsFromId('tracker-control', false)
+  const tcFiles = await fileManager.getCsvItemsFromId('tracker-control')
 
   // Merge the files that have the same headers as the first file
   const tcFile = tcFiles.reduce((prev, curr) => {

--- a/manifests/experiences/tracker-control/pipeline.js
+++ b/manifests/experiences/tracker-control/pipeline.js
@@ -1,5 +1,17 @@
+import { setsEqual } from '~/utils/utils'
+
 async function trackerControl({ fileManager }) {
-  return await fileManager.getCsvItems('input.csv')
+  const tcFiles = await fileManager.getCsvItemsFromId('tracker-control', false)
+
+  // Merge the files that have the same headers as the first file
+  const tcFile = tcFiles.reduce((prev, curr) => {
+    if (setsEqual(new Set(prev.headers), new Set(curr.headers))) {
+      return { headers: prev.headers, items: prev.items.concat(curr.items) }
+    } else {
+      return prev
+    }
+  })
+  return tcFile
 }
 
 export default {

--- a/manifests/experiences/tracker-control/tracker-control.json
+++ b/manifests/experiences/tracker-control/tracker-control.json
@@ -2,15 +2,17 @@
   "title": "TrackerControl",
   "subtitle": "Tracking data",
   "icon": "tracker-control.png",
-  "ext": "csv",
+  "ext": "all",
+  "multiple": true,
   "data": ["tracker-control.csv"],
   "files": {
-    "tracker-control": "input.csv"
+    "tracker-control": "**/*.csv"
   },
   "defaultView": [
     {
       "key": "trackerControl",
       "customPipeline": "trackerControl",
+      "files": ["tracker-control"],
       "visualization": "ChartViewTrackerControl.vue",
       "showTable": false,
       "title": "Dashboard",

--- a/manifests/experiences/tracker-control/tracker-control.json
+++ b/manifests/experiences/tracker-control/tracker-control.json
@@ -2,8 +2,6 @@
   "title": "TrackerControl",
   "subtitle": "Tracking data",
   "icon": "tracker-control.png",
-  "ext": "all",
-  "multiple": true,
   "data": ["tracker-control.csv"],
   "files": {
     "tracker-control": "**/*.csv"

--- a/manifests/experiences/twitter-advertisers-sha/twitter-advertisers-sha.json
+++ b/manifests/experiences/twitter-advertisers-sha/twitter-advertisers-sha.json
@@ -2,7 +2,6 @@
   "title": "Twitter",
   "subtitle": "SHA’d Advertisers",
   "icon": "twittr.png",
-  "ext": "zip",
   "files": ["data/ad-impressions.js", "data/ad-engagements.js"],
   "preprocessor": "twitter",
 	"data": ["twitter.zip", "twitter-sample.zip"]

--- a/manifests/experiences/twitter-advertisers/twitter-advertisers.json
+++ b/manifests/experiences/twitter-advertisers/twitter-advertisers.json
@@ -2,7 +2,6 @@
   "title": "Twitter",
   "subtitle": "Advertisers",
   "icon": "twittr.png",
-  "ext": "zip",
   "files": ["data/ad-impressions.js", "data/ad-engagements.js"],
   "preprocessor": "twitter",
 	"data": ["twitter.zip", "twitter-sample.zip"]

--- a/manifests/experiences/twitter-targeting-information/twitter-targeting-information.json
+++ b/manifests/experiences/twitter-targeting-information/twitter-targeting-information.json
@@ -2,7 +2,6 @@
   "title": "Twitter",
   "subtitle": "Targeting Information",
   "icon": "twittr.png",
-  "ext": "zip",
   "files": ["data/ad-impressions.js", "data/ad-engagements.js"],
   "preprocessor": "twitter",
 	"data": ["twitter.zip", "twitter-sample.zip"],

--- a/manifests/experiences/twitter/__tests__/database.test.js
+++ b/manifests/experiences/twitter/__tests__/database.test.js
@@ -27,7 +27,11 @@ function runQuery(sqlFilePath) {
 }
 
 async function getDatabase(adImpressions, adEngagements) {
-  const fileManager = new FileManager(manifest.preprocessors)
+  const fileManager = new FileManager(
+    manifest.preprocessors,
+    null,
+    manifest.files
+  )
   const fileImpressions = mockFile(
     'test/data/ad-impressions.js',
     JSON.stringify(adImpressions)
@@ -36,11 +40,7 @@ async function getDatabase(adImpressions, adEngagements) {
     'test/data/ad-engagements.js',
     JSON.stringify(adEngagements)
   )
-  await fileManager.init(
-    [fileImpressions, fileEngagements],
-    true,
-    manifest.files
-  )
+  await fileManager.init([fileImpressions, fileEngagements], true)
 
   db = await databaseBuilder(fileManager)
 }

--- a/manifests/experiences/twitter/__tests__/database.test.js
+++ b/manifests/experiences/twitter/__tests__/database.test.js
@@ -40,7 +40,7 @@ async function getDatabase(adImpressions, adEngagements) {
     'test/data/ad-engagements.js',
     JSON.stringify(adEngagements)
   )
-  await fileManager.init([fileImpressions, fileEngagements], true)
+  await fileManager.init([fileImpressions, fileEngagements])
 
   db = await databaseBuilder(fileManager)
 }

--- a/manifests/experiences/twitter/database.js
+++ b/manifests/experiences/twitter/database.js
@@ -22,10 +22,10 @@ export default async function databaseBuilder(fileManager) {
   ])
 
   const impressionsFile = JSON.parse(
-    await fileManager.getPreprocessedTextFromId('impressions')
+    (await fileManager.getPreprocessedTextFromId('impressions'))[0] ?? null
   )
   const engagementsFile = JSON.parse(
-    await fileManager.getPreprocessedTextFromId('engagements')
+    (await fileManager.getPreprocessedTextFromId('engagements'))[0] ?? null
   )
 
   const impressions =

--- a/manifests/experiences/twitter/twitter.json
+++ b/manifests/experiences/twitter/twitter.json
@@ -2,7 +2,6 @@
   "title": "Twitter",
   "icon": "twittr.png",
   "dataPortal": "https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive",
-  "ext": "zip",
   "data": ["twitter.zip", "twitter-sample.zip"],
   "files": {
     "impressions": "**/ad-impressions.js", 

--- a/manifests/experiences/uber/pipeline.js
+++ b/manifests/experiences/uber/pipeline.js
@@ -5,15 +5,18 @@ import {
 } from '~/manifests/generic-pipelines'
 
 async function tripsData({ fileManager }) {
-  return await fileManager.getCsvItemsFromId('trips')
+  return (await fileManager.getCsvItemsFromId('trips'))[0]
 }
 
 async function tripsRawData({ fileManager }) {
-  return await fileManager.getPreprocessedTextFromId('trips')
+  return (await fileManager.getPreprocessedTextFromId('trips'))[0]
 }
 
 async function tripsGraphData({ fileManager }) {
-  const tripsData = await fileManager.getCsvItemsFromId('trips')
+  const tripsData = (await fileManager.getCsvItemsFromId('trips'))[0] ?? {
+    headers: [],
+    items: []
+  }
   const filteredValues = tripsData.items.reduce((acc, d) => {
     // filter non trips data
     if (

--- a/manifests/experiences/uber/uber.json
+++ b/manifests/experiences/uber/uber.json
@@ -3,7 +3,6 @@
   "subtitle": "Customer data",
   "icon": "uber.png",
   "dataPortal": "https://help.uber.com/ubereats/article/request-a-copy-of-your-uber-data",
-  "ext": "zip",
   "files": {
     "trips": "**/Rider/trips_data.csv"
   },

--- a/manifests/experiences/voi/voi.json
+++ b/manifests/experiences/voi/voi.json
@@ -1,10 +1,6 @@
 {
   "title": "Voi",
   "icon": "voi.jpg",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/whatsapp/whatsapp.json
+++ b/manifests/experiences/whatsapp/whatsapp.json
@@ -1,10 +1,6 @@
 {
   "title": "Whatsapp",
   "icon": "whatsapp.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/wolt/wolt.json
+++ b/manifests/experiences/wolt/wolt.json
@@ -1,10 +1,6 @@
 {
   "title": "Wolt",
   "icon": "wolt.png",
-  "ext": "all",
-  "multiple": true,
-  "isGenericViewer": true,
-  "showDataExplorer": true,
   "defaultView": [
     {
       "key": "genericDateViewer",

--- a/manifests/experiences/youtube/youtube.json
+++ b/manifests/experiences/youtube/youtube.json
@@ -1,7 +1,6 @@
 {
   "title": "Youtube",
   "icon": "youtube.png",
-  "ext": "json",
   "data": [],
   "disabled": true
 }

--- a/manifests/index.js
+++ b/manifests/index.js
@@ -63,14 +63,10 @@ const manifests = Object.fromEntries(
       title,
       subtitle = 'Data Experience',
       icon,
-      ext: extensions,
       files = {},
-      multiple = false,
       data: dataFiles = [],
       collaborator,
-      isGenericViewer,
       url,
-      showDataExplorer,
       preprocessors = {},
       timedObservationsViewer = {},
       defaultView = [],
@@ -84,23 +80,18 @@ const manifests = Object.fromEntries(
     let data = dataSamples.filter(({ filename }) =>
       dataFiles.includes(filename)
     )
-    let ext = extensions
 
     if (dir === 'playground') {
       // Add all data samples to playground
       data = dataSamples
-      // All extensions are allowed in the playground
-      ext = validExtensions.join(',')
     }
     // Validate config
     const requiredParams = { title, icon }
-    if (!isGenericViewer && !url) {
-      Object.entries(requiredParams).forEach(([name, param]) => {
-        if (!param) {
-          throw new Error(`[${dir}] ${name} is required`)
-        }
-      })
-    }
+    Object.entries(requiredParams).forEach(([name, param]) => {
+      if (!param) {
+        throw new Error(`[${dir}] ${name} is required`)
+      }
+    })
     Object.values(preprocessors).forEach(preprocessor => {
       if (!(preprocessor in allPreprocessors)) {
         throw new Error(`[${dir}] Preprocessor ${preprocessor} does not exist`)
@@ -112,10 +103,6 @@ const manifests = Object.fromEntries(
         allPreprocessors[preprocessorName]
       ])
     )
-
-    if (isGenericViewer && !showDataExplorer) {
-      throw new Error('the explorer experience must show the data explorer')
-    }
 
     if (_.has(timedObservationsViewer, 'fileMatchers')) {
       timedObservationsViewer.fileMatchers.forEach(m => {
@@ -153,15 +140,11 @@ const manifests = Object.fromEntries(
         title,
         subtitle,
         icon: require(`@/manifests/icons/${icon}`),
-        ext,
         files,
-        multiple,
         data,
         preprocessors: preprocessorFuncs,
         collaborator,
-        isGenericViewer,
         url,
-        showDataExplorer,
         timedObservationsViewer,
         sparql: {},
         vega: {},

--- a/manifests/index.js
+++ b/manifests/index.js
@@ -93,16 +93,13 @@ const manifests = Object.fromEntries(
       ext = validExtensions.join(',')
     }
     // Validate config
-    const requiredParams = { title, icon, ext }
+    const requiredParams = { title, icon }
     if (!isGenericViewer && !url) {
       Object.entries(requiredParams).forEach(([name, param]) => {
         if (!param) {
           throw new Error(`[${dir}] ${name} is required`)
         }
       })
-      if (ext.split(',').some(v => !validExtensions.includes(v))) {
-        throw new Error(`[${dir}] parameter ext is invalid`)
-      }
     }
     Object.values(preprocessors).forEach(preprocessor => {
       if (!(preprocessor in allPreprocessors)) {

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -197,7 +197,8 @@ export default {
         )
         this.fileManager = new FileManager(
           this.manifest.preprocessors,
-          fileManagerWorkers
+          fileManagerWorkers,
+          this.manifest.files
         )
         await this.fileManager.init(files, true)
       } catch (error) {

--- a/pages/import.vue
+++ b/pages/import.vue
@@ -200,7 +200,7 @@ export default {
           fileManagerWorkers,
           this.manifest.files
         )
-        await this.fileManager.init(files, true)
+        await this.fileManager.init(files)
       } catch (error) {
         this.handleError(
           error,

--- a/utils/__mocks__/file-manager-mock.js
+++ b/utils/__mocks__/file-manager-mock.js
@@ -8,6 +8,6 @@ export function mockFile(fileName, content) {
 export async function mockFileManager(fileName, content) {
   const fileManager = new FileManager()
   const file = mockFile(fileName, content)
-  await fileManager.init([file], true)
+  await fileManager.init([file])
   return fileManager
 }

--- a/utils/__mocks__/file-manager-mock.js
+++ b/utils/__mocks__/file-manager-mock.js
@@ -6,7 +6,7 @@ export function mockFile(fileName, content) {
 }
 
 export async function mockFileManager(fileName, content) {
-  const fileManager = new FileManager({})
+  const fileManager = new FileManager()
   const file = mockFile(fileName, content)
   await fileManager.init([file], true)
   return fileManager

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -276,60 +276,34 @@ export default class FileManager {
   /**
    * Return the file path(s) that match the ID.
    * @param {String} id
-   * @param {Boolean} unique return a single result
-   * @returns a String / null (unique=true), or an array (unique=false)
+   * @returns an array
    */
-  getFilePathsFromId(id, unique = true) {
+  getFilePathsFromId(id) {
     if (!(id in this.idToGlob)) {
       throw new Error('ID is not defined')
     }
     const glob = this.idToGlob[id]
-    const paths = this.findMatchingFilePaths(glob)
-    if (unique) {
-      if (paths.length === 0) {
-        return null
-      } else if (paths.length > 1) {
-        console.warn(`Multiple files were found for id="${id}", glob="${glob}"`)
-      }
-      return paths[0]
-    }
-    return paths
+    return this.findMatchingFilePaths(glob)
   }
 
   /**
    * Return the preprocessed text of the file(s) that match the ID.
    * @param {String} id
-   * @param {Boolean} unique return a single result
-   * @returns a String / null (unique=true), or an array (unique=false)
+   * @returns an array
    */
-  async getPreprocessedTextFromId(id, unique = true) {
-    const paths = this.getFilePathsFromId(id, unique)
-    if (unique) {
-      if (paths === null) {
-        return null
-      }
-      return await this.getPreprocessedText(paths)
-    } else {
-      return await Promise.all(paths.map(p => this.getPreprocessedText(p)))
-    }
+  async getPreprocessedTextFromId(id) {
+    const paths = this.getFilePathsFromId(id)
+    return await Promise.all(paths.map(p => this.getPreprocessedText(p)))
   }
 
   /**
    * Return the CSV items of the file(s) that match the ID.
    * @param {String} id
-   * @param {Boolean} unique return a single result
-   * @returns a String / null (unique=true), or an array (unique=false)
+   * @returns an array
    */
-  async getCsvItemsFromId(id, unique = true) {
-    const paths = this.getFilePathsFromId(id, unique)
-    if (unique) {
-      if (paths === null) {
-        return null
-      }
-      return await this.getCsvItems(paths)
-    } else {
-      return await Promise.all(paths.map(p => this.getCsvItems(p)))
-    }
+  async getCsvItemsFromId(id) {
+    const paths = this.getFilePathsFromId(id)
+    return await Promise.all(paths.map(p => this.getCsvItems(p)))
   }
 
   /**

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -81,15 +81,18 @@ export default class FileManager {
   /**
    * Builds a FileManager object without any files, just setting the configuration.
    * @param {Object} preprocessors maps file name to preprocessor function
+   * @param {Object} workers the workers that this file manager should use
+   * @param {Object} idToGlob an object mapping IDs to globs
    */
-  constructor(preprocessors, workers) {
+  constructor(preprocessors, workers, idToGlob) {
     this.supportedExtensions = new Set([
       ...Object.keys(extension2filetype),
       ...Object.values(extension2filetype)
     ])
     this.preprocessors = preprocessors ?? {}
     this.setInitialValues()
-    this.workers = workers
+    this.workers = workers ?? {}
+    this.idToGlob = idToGlob ?? {}
   }
 
   /**
@@ -97,10 +100,9 @@ export default class FileManager {
    * To be called once the files are available.
    * @param {File[]} uppyFiles
    * @param {boolean} multiple
-   * @param {Object} idToGlob an object mapping IDs to globs
    * @returns {Promise<FileManager>}
    */
-  async init(uppyFiles, multiple, idToGlob) {
+  async init(uppyFiles, multiple) {
     this.fileList = await FileManager.extractZips(uppyFiles)
     this.fileList = FileManager.filterFiles(this.fileList)
     const filePairs = this.fileList.map(f => [f.name, f])
@@ -109,7 +111,6 @@ export default class FileManager {
     } else {
       this.fileDict = FileManager.removeTopmostFilenames(filePairs)
     }
-    this.idToGlob = idToGlob
     this.setInitialValues()
     this.setShortFilenames()
     return this

--- a/utils/file-manager.js
+++ b/utils/file-manager.js
@@ -288,46 +288,39 @@ export default class FileManager {
 
   /**
    * Return the file path(s) that match the ID.
-   * If multiple files are found and `unique` is set to true,
-   * print a warning and return only the first one.
-   * If no file is found, return null.
    * @param {String} id
    * @param {Boolean} unique return a single result
-   * @returns a String (unique=true), an array (unique=false), or null
+   * @returns a String / null (unique=true), or an array (unique=false)
    */
   getFilePathsFromId(id, unique = true) {
     if (!(id in this.idToGlob)) {
-      return null
+      throw new Error('ID is not defined')
     }
     const glob = this.idToGlob[id]
     const paths = this.findMatchingFilePaths(glob)
-    if (paths.length === 0) {
-      return null
-    } else if (paths.length > 1) {
-      if (unique) {
+    if (unique) {
+      if (paths.length === 0) {
+        return null
+      } else if (paths.length > 1) {
         console.warn(`Multiple files were found for id="${id}", glob="${glob}"`)
-      } else {
-        return paths
       }
+      return paths[0]
     }
-    return paths[0]
+    return paths
   }
 
   /**
    * Return the preprocessed text of the file(s) that match the ID.
-   * If multiple files are found and `unique` is set to true,
-   * print a warning and return only the first one.
-   * If no file is found, return null.
    * @param {String} id
    * @param {Boolean} unique return a single result
-   * @returns a String (unique=true), an array (unique=false), or null
+   * @returns a String / null (unique=true), or an array (unique=false)
    */
   async getPreprocessedTextFromId(id, unique = true) {
     const paths = this.getFilePathsFromId(id, unique)
-    if (paths === null) {
-      return null
-    }
     if (unique) {
+      if (paths === null) {
+        return null
+      }
       return await this.getPreprocessedText(paths)
     } else {
       return await Promise.all(paths.map(p => this.getPreprocessedText(p)))
@@ -336,19 +329,16 @@ export default class FileManager {
 
   /**
    * Return the CSV items of the file(s) that match the ID.
-   * If multiple files are found and `unique` is set to true,
-   * print a warning and return only the first one.
-   * If no file is found, return null.
    * @param {String} id
    * @param {Boolean} unique return a single result
-   * @returns a String (unique=true), an array (unique=false), or null
+   * @returns a String / null (unique=true), or an array (unique=false)
    */
   async getCsvItemsFromId(id, unique = true) {
     const paths = this.getFilePathsFromId(id, unique)
-    if (paths === null) {
-      return null
-    }
     if (unique) {
+      if (paths === null) {
+        return null
+      }
       return await this.getCsvItems(paths)
     } else {
       return await Promise.all(paths.map(p => this.getCsvItems(p)))

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -5,13 +5,13 @@ import { itemifyJSON } from '~/utils/json'
 import getCsvHeadersAndItems from '~/utils/csv'
 
 test('an empty file manager', async () => {
-  const fileManager = new FileManager({})
+  const fileManager = new FileManager()
   fileManager.init([], false)
   await expect(() => fileManager.getText('bobo.json')).rejects.toThrow()
 })
 
 test('a json file in file manager', async () => {
-  const fileManager = new FileManager({})
+  const fileManager = new FileManager()
   const fileName = 'bibi/bobo.json'
   const content = '{"hello": 1}'
   const file = mockFile(fileName, content)
@@ -31,7 +31,7 @@ test('a json file in file manager', async () => {
 })
 
 test('a csv file in file manager', async () => {
-  const fileManager = new FileManager({}, true)
+  const fileManager = new FileManager()
   const fileName = 'test.csv'
   const content = 'col1,col2\nhello,world\nfoo,bar'
   const file = mockFile(fileName, content)
@@ -52,7 +52,7 @@ test('a csv file in file manager', async () => {
 })
 
 test('findMatchingFilePaths', async () => {
-  const fileManager = new FileManager({})
+  const fileManager = new FileManager()
   const fileName1 = 'bibi/bubo.json'
   const fileContent = '{"hello": [11,22,33]}'
   const file1 = mockFile(fileName1, fileContent)
@@ -71,7 +71,7 @@ test('findMatchingFilePaths', async () => {
 })
 
 test('findMatchingObjects', async () => {
-  const fileManager = new FileManager({})
+  const fileManager = new FileManager()
   const fileName = 'bibi/bubo.json'
   const fileContent = '{"hello": [11,22,33]}'
   const file = mockFile(fileName, fileContent)
@@ -92,7 +92,7 @@ test('findMatchingObjects', async () => {
 })
 
 test('short filenames', async () => {
-  const fileManager = new FileManager({})
+  const fileManager = new FileManager()
   const f1 = 'foo/bar.txt'
   const f2 = 'foo/toc.txt'
   const f3 = 'bar.txt'
@@ -116,7 +116,7 @@ test('short filenames', async () => {
 })
 
 test('files are filtered', async () => {
-  const fileManager = new FileManager({})
+  const fileManager = new FileManager()
   const f1 = mockFile('__MACOSX/ignored.txt', '')
   const f2 = mockFile('test/.DS_STORE', '')
   const f3 = mockFile('test/.DS_Store', '')
@@ -128,7 +128,6 @@ test('files are filtered', async () => {
 })
 
 test('files from IDs', async () => {
-  const fileManager = new FileManager({})
   const content = 'hello world'
 
   const id1 = 'foobar'
@@ -147,7 +146,8 @@ test('files from IDs', async () => {
     [id3]: '**/*.txt',
     [id4]: '*.unknown'
   }
-  await fileManager.init([file1, file2], true, ids)
+  const fileManager = new FileManager(null, null, ids)
+  await fileManager.init([file1, file2], true)
 
   let path, text
   path = fileManager.getFilePathsFromId(id1, true)

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -147,21 +147,20 @@ test('files from IDs', async () => {
   await fileManager.init([file1, file2])
 
   let path, text
-  path = fileManager.getFilePathsFromId(id1, true)
-  expect(path).toStrictEqual(path1)
-  text = await fileManager.getPreprocessedTextFromId(id1, true)
-  expect(text).toStrictEqual(content)
+  path = fileManager.getFilePathsFromId(id1)
+  expect(path).toEqual([path1])
+  text = await fileManager.getPreprocessedTextFromId(id1)
+  expect(text).toEqual([content])
 
-  path = fileManager.getFilePathsFromId(id2, true)
-  expect(path).toStrictEqual(path2)
-  text = await fileManager.getPreprocessedTextFromId(id2, true)
-  expect(text).toStrictEqual(content)
+  path = fileManager.getFilePathsFromId(id2)
+  expect(path).toEqual([path2])
+  text = await fileManager.getPreprocessedTextFromId(id2)
+  expect(text).toEqual([content])
 
-  const paths = fileManager.getFilePathsFromId(id3, false)
+  const paths = fileManager.getFilePathsFromId(id3)
   arrayEqualNoOrder(paths, [path1, path2])
 
-  expect(() => fileManager.getFilePathsFromId('wrong-id', true)).toThrow()
+  expect(() => fileManager.getFilePathsFromId('wrong-id')).toThrow()
 
-  expect(fileManager.getFilePathsFromId(id4, true)).toBe(null)
-  expect(fileManager.getFilePathsFromId(id4, false)).toEqual([])
+  expect(fileManager.getFilePathsFromId(id4)).toEqual([])
 })

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -6,7 +6,7 @@ import getCsvHeadersAndItems from '~/utils/csv'
 
 test('an empty file manager', async () => {
   const fileManager = new FileManager()
-  fileManager.init([], false)
+  fileManager.init([])
   await expect(() => fileManager.getText('bobo.json')).rejects.toThrow()
 })
 
@@ -15,7 +15,7 @@ test('a json file in file manager', async () => {
   const fileName = 'bibi/bobo.json'
   const content = '{"hello": 1}'
   const file = mockFile(fileName, content)
-  await fileManager.init([file], true)
+  await fileManager.init([file])
 
   expect(fileManager.hasFile(fileName)).toBeTruthy()
 
@@ -35,7 +35,7 @@ test('a csv file in file manager', async () => {
   const fileName = 'test.csv'
   const content = 'col1,col2\nhello,world\nfoo,bar'
   const file = mockFile(fileName, content)
-  await fileManager.init([file], true)
+  await fileManager.init([file])
 
   expect(fileManager.hasFile(fileName)).toBeTruthy()
 
@@ -58,7 +58,7 @@ test('findMatchingFilePaths', async () => {
   const file1 = mockFile(fileName1, fileContent)
   const fileName2 = 'bibi/bibo.json'
   const file2 = mockFile(fileName2, fileContent)
-  await fileManager.init([file1, file2], true)
+  await fileManager.init([file1, file2])
 
   let paths = fileManager.findMatchingFilePaths('**/b*bo.json')
   expect(paths).toStrictEqual([fileName1, fileName2])
@@ -75,7 +75,7 @@ test('findMatchingObjects', async () => {
   const fileName = 'bibi/bubo.json'
   const fileContent = '{"hello": [11,22,33]}'
   const file = mockFile(fileName, fileContent)
-  await fileManager.init([file], true)
+  await fileManager.init([file])
 
   expect(fileManager.hasFile(fileName)).toBeTruthy()
   const bobo = await fileManager.getText(fileName)
@@ -98,16 +98,13 @@ test('short filenames', async () => {
   const f3 = 'bar.txt'
   const f4 = 'test/hello/bar.txt'
   const f5 = 'zip.zip/toc.json'
-  await fileManager.init(
-    [
-      mockFile(f1, ''),
-      mockFile(f2, ''),
-      mockFile(f3, ''),
-      mockFile(f4, ''),
-      mockFile(f5, '')
-    ],
-    true
-  )
+  await fileManager.init([
+    mockFile(f1, ''),
+    mockFile(f2, ''),
+    mockFile(f3, ''),
+    mockFile(f4, ''),
+    mockFile(f5, '')
+  ])
   expect(fileManager.getShortFilename(f1)).toMatch('foo/bar.txt')
   expect(fileManager.getShortFilename(f2)).toMatch('toc.txt')
   expect(fileManager.getShortFilename(f3)).toMatch('bar.txt')
@@ -120,7 +117,7 @@ test('files are filtered', async () => {
   const f1 = mockFile('__MACOSX/ignored.txt', '')
   const f2 = mockFile('test/.DS_STORE', '')
   const f3 = mockFile('test/.DS_Store', '')
-  await fileManager.init([f1, f2, f3], true)
+  await fileManager.init([f1, f2, f3])
 
   expect(fileManager.hasFile(f1)).toBeFalsy()
   expect(fileManager.hasFile(f2)).toBeFalsy()
@@ -147,7 +144,7 @@ test('files from IDs', async () => {
     [id4]: '*.unknown'
   }
   const fileManager = new FileManager(null, null, ids)
-  await fileManager.init([file1, file2], true)
+  await fileManager.init([file1, file2])
 
   let path, text
   path = fileManager.getFilePathsFromId(id1, true)

--- a/utils/file-manager.test.js
+++ b/utils/file-manager.test.js
@@ -140,10 +140,12 @@ test('files from IDs', async () => {
   const file2 = mockFile(path2, content)
 
   const id3 = 'all'
+  const id4 = 'not-found'
   const ids = {
     [id1]: '**/bar.txt',
     [id2]: '**/hello.txt',
-    [id3]: '**/*.txt'
+    [id3]: '**/*.txt',
+    [id4]: '*.unknown'
   }
   await fileManager.init([file1, file2], true, ids)
 
@@ -161,5 +163,8 @@ test('files from IDs', async () => {
   const paths = fileManager.getFilePathsFromId(id3, false)
   arrayEqualNoOrder(paths, [path1, path2])
 
-  expect(fileManager.getFilePathsFromId('wrong-id', true)).toBe(null)
+  expect(() => fileManager.getFilePathsFromId('wrong-id', true)).toThrow()
+
+  expect(fileManager.getFilePathsFromId(id4, true)).toBe(null)
+  expect(fileManager.getFilePathsFromId(id4, false)).toEqual([])
 })

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -107,3 +107,8 @@ export function runWorker(worker, args) {
 
 export const setTimeoutPromise = (delay, value) =>
   new Promise(resolve => setTimeout(resolve, delay, value))
+
+/* Shallow equality test on sets */
+export function setsEqual(s1, s2) {
+  return s1.size === s2.size && [...s1].every(value => s2.has(value))
+}


### PR DESCRIPTION
Changes:
- Add the functionality defined in #501. This can create some ambiguities in the pipelines about which files we need to use (i.e. what if the user puts two different twitter archives?), so here's how they handle it:
  - Tracker control takes all CSV found, and concatenates them if they have the same structure. Otherwise it takes the first one found.
  - Tinder takes the first JSON found (according to [the tinder shex](https://github.com/hestiaAI/data-catalog/blob/main/shex/tinder.shex) there is only one JSON in the archive)
  - Twitter/Facebook/Uber take the first file found
- Remove obsolete options from manifests (`ext`, `multiple`, `isGenericViewer`, `showDataExplorer`)
- Remove obsolete options from file-manager and refactor, with a slight functionality change (`removeTopmostFilenames` has been replaced by `removeZipName`, see docstring)
- Add found files in sub-experience dialogs

Note for the future: To better handle the ambiguities, we have the following options:
- Try to merge the files
- Show a warning to the user saying which file we are using
- Ask the user to choose the file they want to use