### PR TITLE
fix: google my activity

### DIFF
--- a/components/unit/UnitPipelineCustom.vue
+++ b/components/unit/UnitPipelineCustom.vue
@@ -103,13 +103,11 @@ export default {
         const optionsObject = JSON.parse(this.options || 'null')
         const result = await this.customPipeline({
           fileManager: this.fileManager,
-          manifest: this.$store.getters.manifest(this.$route),
           parameter: this.parameter,
           options: optionsObject
         })
-        this.$emit('update', result)
+        this.$emit('update', { result })
       } catch (error) {
-        console.error(error)
         this.error = true
         this.$emit('update', { error })
       } finally {

--- a/components/unit/UnitPipelineSparql.vue
+++ b/components/unit/UnitPipelineSparql.vue
@@ -42,10 +42,9 @@ export default {
         this.error = false
         this.progress = true
 
-        const results = await quadstore.select(this.sparqlQuery)
-        this.$emit('update', results)
+        const result = await quadstore.select(this.sparqlQuery)
+        this.$emit('update', { result })
       } catch (error) {
-        console.error(error)
         this.error = true
         this.$emit('update', { error })
       } finally {

--- a/components/unit/UnitPipelineSql.vue
+++ b/components/unit/UnitPipelineSql.vue
@@ -61,10 +61,9 @@ export default {
       setTimeout(() => {
         try {
           const params = { [this.parameterKey]: this.parameter }
-          const { headers, items } = this.currentDB.select(this.sql, params)
-          this.$emit('update', { headers, items })
+          const result = this.currentDB.select(this.sql, params)
+          this.$emit('update', { result })
         } catch (error) {
-          console.error(error)
           this.error = true
           this.$emit('update', { error })
         } finally {

--- a/components/unit/UnitQuery.vue
+++ b/components/unit/UnitQuery.vue
@@ -74,6 +74,13 @@
             />
           </VCol>
         </VRow>
+        <VRow v-if="errorMessage">
+          <VCol>
+            <BaseAlert type="error">
+              {{ errorMessage }}
+            </BaseAlert>
+          </VCol>
+        </VRow>
         <template v-if="clonedResult">
           <VRow>
             <VCol>
@@ -140,6 +147,11 @@ export default {
       default: () => {}
     }
   },
+  data() {
+    return {
+      errorMessage: ''
+    }
+  },
   computed: {
     ...mapGetters(['fileManager']),
     showTable() {
@@ -183,7 +195,12 @@ export default {
     }
   },
   methods: {
-    onUnitResultsUpdate(result) {
+    onUnitResultsUpdate({ result, error }) {
+      if (error) {
+        console.error(error)
+        this.errorMessage = error instanceof Error ? error.message : error
+        return
+      }
       // Postprocessing
       if (this.defaultViewElements.postprocessor !== undefined) {
         result =

--- a/manifests/experiences/google/google.json
+++ b/manifests/experiences/google/google.json
@@ -3,122 +3,122 @@
   "icon": "google.png",
   "dataPortal": "https://takeout.google.com/settings/takeout",
   "data": [],
-  "timedObservationsViewer": {
-    "fileMatchers": [
-      {
-        "regex": "(?:.*/)?(.+?)/(?:OmatTapahtumat|MonActivité|My Activity)\\.json",
-        "entryPath": "$[*]",
-        "fields": {
-          "date": {
-            "source": "entry",
-            "path": "$.time"
-          },
-          "eventValue": {
-            "source": "entry",
-            "path": "$.title"
-          },
-          "eventSource": {
-            "source": "regex",
-            "path": "1"
-          }
-        }
-      }
-    ],
-    "parser": "identifyTypeFromManifestList",
-    "eventTypes": {
-      "en": {
-        "Agenda": ["Searched"],
-        "Audio search": ["Listened"],
-        "Podcasts": ["Listened"],
-        "Voice and audio": ["said"],
-        "Assistant": ["Used", "notification"],
-        "Android": ["Used"],
-        "YouTube": ["Liked", "Disliked", "Subscribed to", "Watched", "Searched", "Saved", "Visited"],
-        "Search": ["Searched", "Visited", "Defined", "Viewed", "Used"],
-        "Maps": ["Viewed", "Directions", "Opened My Maps", "Searched", "Used Maps", "Viewed area", "Explored", "Used"],
-        "Image Search": ["Searched", "Viewed", "Used"],
-        "Google Play Store": ["Visited", "Uninstalled", "Searched", "Installed", "Used"],
-        "Ads": ["Visited"],
-        "Video Search": ["Watched", "Searched"],
-        "Help": ["Visited", "Viewed", "Searched", "Interacted"],
-        "Google Play Games": ["Played"],
-        "Google Apps": ["Searched", "Selected"],
-        "Google Lens": ["Searched"],
-        "Google Cloud": ["Searched", "Visited"],
-        "Shopping": ["Viewed"],
-        "Books": ["Viewed", "Searched"],
-        "Developers": ["Visited", "Viewed"],
-        "Discover": [],
-        "News": ["Visited", "Searched"],
-        "Gmail": ["Searched"],
-        "Drive": ["bulk download", "Searched"],
-        "Google Pay": ["contactless payment that failed", "contactless payment", "Used Google Pay"],
-        "Takeout": ["Downloaded a Takeout archive", "Initiated a Takeout"]
-      },
-      "fr": {
-        "Agenda": ["recherché"],
-        "Recherche audio": ["écouté"],
-        "Podcasts": ["écouté"],
-        "Assistant": ["utilisée", "notification"],
-        "Voix et audio": ["dit"],
-        "YouTube": ["aimé", "n'a pas aimé", "abonné à", "regardé", "recherché", "enregistré", "consulté"],
-        "Recherche" : ["recherché", "visité", "Défini", "consulté", "utilisé", "Application ouverte"],
-        "Maps" : ["Zone consultée", "Itinéraire", "Carte My Maps ouverte", "recherché", "Cartes consultées", "explorée", "utilisée", "Lieu découvert", "Maps ouverte"],
-        "Recherche d_images" : ["recherché", "consulté", "utilisé"],
-        "Google Play Store" : ["consulté", "Désinstallée", "recherché", "Installée", "utilisé"],
-        "Solutions publicitaires" : ["consulté"],
-        "Recherche de vidéos" : ["regardé", "recherché"],
-        "Aide" : ["visité", "consulté", "recherché", "interagi"],
-        "Google Play Jeux" : ["joué"],
-        "Google Apps" : ["recherché", "sélectionné"],
-        "Google Lens" : ["Recherche"],
-        "Google Cloud" : ["recherché", "consulté"],
-        "Shopping" : ["consulté"],
-        "Livres" : ["consulté", "recherché"],
-        "Android": ["utilisée"],
-        "Google Developers" : ["consulté", "visité"],
-        "Découvrir": [],
-        "Google Actualités": ["consulté", "recherché"],
-        "Gmail" : ["recherché"],
-        "Drive" : ["téléchargement groupé", "recherché"],
-        "Google Pay" : ["paiement sans contact qui a échoué", "paiement sans contact", "utilisé"],
-        "Takeout": ["téléchargé une archive Takeout", "lancé une opération"]
-      },
-      "fi": {
-        "Agenda": ["Haku"],
-        "Assistant": ["Käytetty", "ilmoitus"],
-        "Äänihaku": ["Kuunneltu"],
-        "Podcastit": ["Kuunneltu"],
-        "Voice and audio": ["Sanoi"],
-        "Android": ["Käytetty"],
-        "Haku": ["Käytetty", "Haku", "avattiin", "katsottiin", "Määritelty", "Katsotut"],
-        "YouTube": ["Tallennettu", "katsottiin", "Haku", "Tykkäsit", "Et tykännyt", "tilattu", "Katsoi myöhemmin poistetun videon", "avattiin"],
-        "Maps": ["Katsottu", "Reittiohjeet", "Avoin omat kartat", "Haku", "Käytetyt kartat", "Katsottu alue", "Tutkittu", "Käytetty"],
-        "Kuvahaku": ["Haku", "Katsottu", "Käytetty"],
-        "Google Play Kauppa": ["avattiin", "Poistettu", "Haku", "Asennettu", "käytettiin"],
-        "Ads": ["avattiin"],
-        "Videohaku": ["katsottiin", "Haku"],
-        "Ohje": ["avattiin", "käytettiin", "Haku", "Tarkasteli"],
-        "Google Play Pelit": ["Pelasi kohdetta"],
-        "Google Apps for Work": ["Haku", "Valittu"],
-        "Google Lens": ["Lens-haku"],
-        "Google Cloud": ["Haku", "avattiin"],
-        "Shopping": ["Katsoi"],
-        "Kirjat": ["Katsottu", "Haku"],
-        "Developers": ["katsottiin", "avattiin"],
-        "Löydä": [],
-        "Uutiset": ["Haku", "avattiin"],
-        "Gmail": ["Haku"],
-        "Drive": ["käynnistettiin", "Haku"],
-        "Google Pay": ["lähimaksu, joka epäonnistui", "lähimaksu", "Käytetty Google Pay"],
-        "Takeout": ["käynnistettiin", "ladattiin"]
-      }
-    }
-  },
   "defaultView": [
     {
       "key": "timedObservationViewer",
       "customPipeline": "timedObservationViewer",
+      "customPipelineOptions": {
+        "fileMatchers": [
+          {
+            "regex": "(?:.*/)?(.+?)/(?:OmatTapahtumat|MonActivité|My Activity)\\.json",
+            "entryPath": "$[*]",
+            "fields": {
+              "date": {
+                "source": "entry",
+                "path": "$.time"
+              },
+              "eventValue": {
+                "source": "entry",
+                "path": "$.title"
+              },
+              "eventSource": {
+                "source": "regex",
+                "path": "1"
+              }
+            }
+          }
+        ],
+        "parser": "identifyTypeFromManifestList",
+        "eventTypes": {
+          "en": {
+            "Agenda": ["Searched"],
+            "Audio search": ["Listened"],
+            "Podcasts": ["Listened"],
+            "Voice and audio": ["said"],
+            "Assistant": ["Used", "notification"],
+            "Android": ["Used"],
+            "YouTube": ["Liked", "Disliked", "Subscribed to", "Watched", "Searched", "Saved", "Visited"],
+            "Search": ["Searched", "Visited", "Defined", "Viewed", "Used"],
+            "Maps": ["Viewed", "Directions", "Opened My Maps", "Searched", "Used Maps", "Viewed area", "Explored", "Used"],
+            "Image Search": ["Searched", "Viewed", "Used"],
+            "Google Play Store": ["Visited", "Uninstalled", "Searched", "Installed", "Used"],
+            "Ads": ["Visited"],
+            "Video Search": ["Watched", "Searched"],
+            "Help": ["Visited", "Viewed", "Searched", "Interacted"],
+            "Google Play Games": ["Played"],
+            "Google Apps": ["Searched", "Selected"],
+            "Google Lens": ["Searched"],
+            "Google Cloud": ["Searched", "Visited"],
+            "Shopping": ["Viewed"],
+            "Books": ["Viewed", "Searched"],
+            "Developers": ["Visited", "Viewed"],
+            "Discover": [],
+            "News": ["Visited", "Searched"],
+            "Gmail": ["Searched"],
+            "Drive": ["bulk download", "Searched"],
+            "Google Pay": ["contactless payment that failed", "contactless payment", "Used Google Pay"],
+            "Takeout": ["Downloaded a Takeout archive", "Initiated a Takeout"]
+          },
+          "fr": {
+            "Agenda": ["recherché"],
+            "Recherche audio": ["écouté"],
+            "Podcasts": ["écouté"],
+            "Assistant": ["utilisée", "notification"],
+            "Voix et audio": ["dit"],
+            "YouTube": ["aimé", "n'a pas aimé", "abonné à", "regardé", "recherché", "enregistré", "consulté"],
+            "Recherche" : ["recherché", "visité", "Défini", "consulté", "utilisé", "Application ouverte"],
+            "Maps" : ["Zone consultée", "Itinéraire", "Carte My Maps ouverte", "recherché", "Cartes consultées", "explorée", "utilisée", "Lieu découvert", "Maps ouverte"],
+            "Recherche d_images" : ["recherché", "consulté", "utilisé"],
+            "Google Play Store" : ["consulté", "Désinstallée", "recherché", "Installée", "utilisé"],
+            "Solutions publicitaires" : ["consulté"],
+            "Recherche de vidéos" : ["regardé", "recherché"],
+            "Aide" : ["visité", "consulté", "recherché", "interagi"],
+            "Google Play Jeux" : ["joué"],
+            "Google Apps" : ["recherché", "sélectionné"],
+            "Google Lens" : ["Recherche"],
+            "Google Cloud" : ["recherché", "consulté"],
+            "Shopping" : ["consulté"],
+            "Livres" : ["consulté", "recherché"],
+            "Android": ["utilisée"],
+            "Google Developers" : ["consulté", "visité"],
+            "Découvrir": [],
+            "Google Actualités": ["consulté", "recherché"],
+            "Gmail" : ["recherché"],
+            "Drive" : ["téléchargement groupé", "recherché"],
+            "Google Pay" : ["paiement sans contact qui a échoué", "paiement sans contact", "utilisé"],
+            "Takeout": ["téléchargé une archive Takeout", "lancé une opération"]
+          },
+          "fi": {
+            "Agenda": ["Haku"],
+            "Assistant": ["Käytetty", "ilmoitus"],
+            "Äänihaku": ["Kuunneltu"],
+            "Podcastit": ["Kuunneltu"],
+            "Voice and audio": ["Sanoi"],
+            "Android": ["Käytetty"],
+            "Haku": ["Käytetty", "Haku", "avattiin", "katsottiin", "Määritelty", "Katsotut"],
+            "YouTube": ["Tallennettu", "katsottiin", "Haku", "Tykkäsit", "Et tykännyt", "tilattu", "Katsoi myöhemmin poistetun videon", "avattiin"],
+            "Maps": ["Katsottu", "Reittiohjeet", "Avoin omat kartat", "Haku", "Käytetyt kartat", "Katsottu alue", "Tutkittu", "Käytetty"],
+            "Kuvahaku": ["Haku", "Katsottu", "Käytetty"],
+            "Google Play Kauppa": ["avattiin", "Poistettu", "Haku", "Asennettu", "käytettiin"],
+            "Ads": ["avattiin"],
+            "Videohaku": ["katsottiin", "Haku"],
+            "Ohje": ["avattiin", "käytettiin", "Haku", "Tarkasteli"],
+            "Google Play Pelit": ["Pelasi kohdetta"],
+            "Google Apps for Work": ["Haku", "Valittu"],
+            "Google Lens": ["Lens-haku"],
+            "Google Cloud": ["Haku", "avattiin"],
+            "Shopping": ["Katsoi"],
+            "Kirjat": ["Katsottu", "Haku"],
+            "Developers": ["katsottiin", "avattiin"],
+            "Löydä": [],
+            "Uutiset": ["Haku", "avattiin"],
+            "Gmail": ["Haku"],
+            "Drive": ["käynnistettiin", "Haku"],
+            "Google Pay": ["lähimaksu, joka epäonnistui", "lähimaksu", "Käytetty Google Pay"],
+            "Takeout": ["käynnistettiin", "ladattiin"]
+          }
+        }
+      },
       "visualization": "ChartViewTimedObservationsViewer.vue",
       "showTable": false,
       "title": "My activity information",

--- a/manifests/experiences/google/google.json
+++ b/manifests/experiences/google/google.json
@@ -3,10 +3,14 @@
   "icon": "google.png",
   "dataPortal": "https://takeout.google.com/settings/takeout",
   "data": [],
+  "files": {
+    "my-activity": "**/*/+(OmatTapahtumat|MonActivité|My Activity).json"
+  },
   "defaultView": [
     {
       "key": "timedObservationViewer",
       "customPipeline": "timedObservationViewer",
+      "files": ["my-activity"],
       "customPipelineOptions": {
         "fileMatchers": [
           {

--- a/manifests/index.js
+++ b/manifests/index.js
@@ -1,7 +1,6 @@
 import _ from 'lodash'
 
 import allPreprocessors from './preprocessors'
-import allParsers from './parsers'
 
 import { validExtensions, extractFirstDirectory } from './utils'
 
@@ -68,7 +67,6 @@ const manifests = Object.fromEntries(
       collaborator,
       url,
       preprocessors = {},
-      timedObservationsViewer = {},
       defaultView = [],
       ...rest
     } = reqJSON(path)
@@ -104,26 +102,6 @@ const manifests = Object.fromEntries(
       ])
     )
 
-    if (_.has(timedObservationsViewer, 'fileMatchers')) {
-      timedObservationsViewer.fileMatchers.forEach(m => {
-        try {
-          m.regex = new RegExp(m.regex)
-        } catch (error) {
-          throw new Error(`The regex '${m.regex}' is not valid`)
-        }
-      })
-    }
-    if (_.has(timedObservationsViewer, 'parser')) {
-      const parser = timedObservationsViewer.parser
-      if (parser in allParsers) {
-        timedObservationsViewer.parser = allParsers[parser]
-      } else {
-        throw new Error(`The parser ${parser} doesn't exist`)
-      }
-    } else {
-      timedObservationsViewer.parser = _.identity
-    }
-
     const firstNoKey = _.find(defaultView, v => !_.has(v, 'key'))
     if (firstNoKey != null) {
       throw new Error(
@@ -145,7 +123,6 @@ const manifests = Object.fromEntries(
         preprocessors: preprocessorFuncs,
         collaborator,
         url,
-        timedObservationsViewer,
         sparql: {},
         vega: {},
         sql: {},


### PR DESCRIPTION
Close #448
Related to #480

Now that we can edit custom pipelines options, it really makes sense to put the google `timedObservationsViewer` in the `customPipelineOptions` instead of having it at the root of the manifest. Thanks to this, custom pipelines no longer need to pass the entire manifest.

I also added file indications for this experience.

Finally, I improved the error handling for all the pipelines. Now, if an unexpected problem occurs, it will show an error message to the user.