### PR TITLE
fix: legend spacing + number of ticks using d3

### DIFF
--- a/components/chart/view/ChartViewHeatMapHour.vue
+++ b/components/chart/view/ChartViewHeatMapHour.vue
@@ -55,12 +55,7 @@
             <rect
               :width="(cellSize - cellSpacing) * 2"
               :height="(cellSize - cellSpacing) / 2"
-              :x="
-                width -
-                cellSize * 2 * legendNbItems +
-                idx * cellSize * 2 -
-                cellSize * 2
-              "
+              :x="legendSquareXPos(idx)"
               :y="height - cellSize * 3"
               :fill="color(square)"
               :rx="borderRadius"
@@ -68,12 +63,7 @@
             ></rect>
             <text
               style="text-anchor: middle"
-              :x="
-                width -
-                cellSize * 2 * legendNbItems +
-                idx * cellSize * 2 -
-                cellSize
-              "
+              :x="legendSquareXPos(idx)"
               :y="height - cellSize * 2"
             >
               {{ square }}
@@ -194,7 +184,11 @@ export default {
         ' records'
       )
     },
-    drawViz() {}
+    drawViz() {},
+    legendSquareXPos(idx) {
+      const { width: w, cellSize: s, legendNbItems: n } = this
+      return w - s * 2 * n + idx * s * 2 - s * 2
+    }
   }
 }
 </script>

--- a/components/chart/view/ChartViewHeatMapHour.vue
+++ b/components/chart/view/ChartViewHeatMapHour.vue
@@ -45,7 +45,7 @@
         <g class="legend">
           <text
             style="text-anchor: end"
-            :x="width - cellSize * legendNbItems * 3"
+            :x="width - cellSize * 2 * legendNbItems - cellSize * 3"
             :y="height - cellSize * 2.5"
             dy="-.20em"
           >
@@ -57,9 +57,9 @@
               :height="(cellSize - cellSpacing) / 2"
               :x="
                 width -
-                cellSize * legendNbItems * 3 +
-                idx * cellSize * 2 +
-                cellSize
+                cellSize * 2 * legendNbItems +
+                idx * cellSize * 2 -
+                cellSize * 2
               "
               :y="height - cellSize * 3"
               :fill="color(square)"
@@ -70,10 +70,9 @@
               style="text-anchor: middle"
               :x="
                 width -
-                cellSize * legendNbItems * 3 +
-                idx * cellSize * 2 +
-                2 * cellSize +
-                0.5
+                cellSize * 2 * legendNbItems +
+                idx * cellSize * 2 -
+                cellSize
               "
               :y="height - cellSize * 2"
             >
@@ -121,7 +120,7 @@ export default {
       type: Number,
       default: () => 3
     },
-    legendNbItems: {
+    legendPrefNbItems: {
       type: Number,
       default: () => 4
     },
@@ -175,14 +174,14 @@ export default {
       return d3
         .scaleSequential()
         .domain([this.extent[0], this.extent[1]])
+        .nice()
         .interpolator(this.colorPalette)
     },
     legendSquares() {
-      const legendFormat = d3.format('.2')
-      const step = this.extent[1] / (this.legendNbItems - 1)
-      return d3
-        .range(this.legendNbItems)
-        .map(n => (n ? legendFormat(n * step) : legendFormat(this.extent[0])))
+      return this.color.ticks(this.legendPrefNbItems)
+    },
+    legendNbItems() {
+      return this.legendSquares.length
     }
   },
   mounted() {},


### PR DESCRIPTION
This PR is related to #638.

Instead of manually calculating the ticks, we use the d3 scale.ticks method, if the number of ticks chosen is less than the extent, it should still display nice integer ticks. 

I also corrected the position computation of the legend.
