### PR TITLE
fix: add primaryKey property

### DIFF
--- a/manifests/experiences/twitter/__tests__/database.test.js
+++ b/manifests/experiences/twitter/__tests__/database.test.js
@@ -84,16 +84,14 @@ describe('with complete samples', () => {
     // Table TwitterCriterion
     result = db.select('SELECT * FROM TwitterCriterion')
     expected = {
-      headers: ['id', 'adId', 'targetingType', 'targetingValue'],
+      headers: ['adId', 'targetingType', 'targetingValue'],
       items: [
         {
-          id: 1,
           adId: 1,
           targetingType: 'Locations',
           targetingValue: 'Switzerland'
         },
         {
-          id: 2,
           adId: 1,
           targetingType: 'Age',
           targetingValue: '35 and up'

--- a/manifests/experiences/twitter/twitter.json
+++ b/manifests/experiences/twitter/twitter.json
@@ -84,17 +84,18 @@
       {
         "name": "TwitterAd",
         "columns": [
-          ["id", "INTEGER", "PRIMARY KEY AUTOINCREMENT"],
+          ["id", "INTEGER"],
           ["tweetId", "TEXT"],
           ["advertiserName", "TEXT"],
           ["displayLocation", "TEXT"],
           ["time", "DATE"]
-        ]
+        ],
+        "primaryKey": "id"
       },
       {
         "name": "TwitterEngagement",
         "columns": [
-          ["id", "INTEGER", "PRIMARY KEY AUTOINCREMENT"],
+          ["id", "INTEGER"],
           ["tweetId", "TEXT"],
           ["advertiserName", "TEXT"],
           ["displayLocation", "TEXT"],
@@ -104,7 +105,6 @@
       {
         "name": "TwitterCriterion",
         "columns": [
-          ["id", "INTEGER", "PRIMARY KEY AUTOINCREMENT"],
           ["adId", "INTEGER"],
           ["targetingType", "TEXT"],
           ["targetingValue", "TEXT"]

--- a/manifests/validate-database-config.js
+++ b/manifests/validate-database-config.js
@@ -19,10 +19,17 @@ const columnSchema = {
 
 const columnsSchema = {
   $id: `${prefix}columns`,
-  type: 'array',
-  items: {
-    $ref: '#column'
-  }
+  anyOf: [
+    {
+      $ref: '#column'
+    },
+    {
+      type: 'array',
+      items: {
+        $ref: '#column'
+      }
+    }
+  ]
 }
 
 const gettersSchema = {
@@ -136,14 +143,14 @@ const schema = {
               type: 'object',
               properties: {
                 columns: {
-                  anyOf: [{ $ref: '#column' }, { $ref: '#columns' }]
+                  $ref: '#columns'
                 },
                 reference: {
                   type: 'object',
                   properties: {
                     table: { $ref: '#tableName' },
                     columns: {
-                      anyOf: [{ $ref: '#column' }, { $ref: '#columns' }]
+                      $ref: '#columns'
                     }
                   },
                   required: ['table', 'columns']
@@ -151,6 +158,9 @@ const schema = {
               }
             },
             required: ['columns', 'reference']
+          },
+          primaryKey: {
+            $ref: '#columns'
           }
         },
         required: ['name', 'columns']

--- a/utils/sql.test.js
+++ b/utils/sql.test.js
@@ -2,7 +2,9 @@ import { DB } from '@/utils/sql'
 
 // The .wasm file import must be mocked, see jest.moduleNameMapper in package.json
 
-const testTable = [
+const format = ([name, columns]) => ({ name, columns })
+
+const testTable = format([
   'test',
   [
     ['id', 'INTEGER'],
@@ -10,12 +12,12 @@ const testTable = [
     ['time', 'DATE'],
     ['ratio', 'FLOAT']
   ]
-]
+])
 
-const testTableWrongTableName = ['test', [['foo$bar', 'INTEGER']]]
-const testTableWrongColumnName = ['test', [['foo$bar', 'INTEGER']]]
-const testTableWrongType = ['test', [['id', 'FOO']]]
-const testTableMissingType = ['test', [['id']]]
+const testTableWrongTableName = format(['test', [['foo$bar', 'INTEGER']]])
+const testTableWrongColumnName = format(['test', [['foo$bar', 'INTEGER']]])
+const testTableWrongType = format(['test', [['id', 'FOO']]])
+const testTableMissingType = format(['test', [['id']]])
 
 const testItems = [
   { id: 0, description: 'hello world', time: '2021-12-31', ratio: 0.5 },
@@ -45,31 +47,31 @@ test('initializing and closing a database without error', async () => {
 describe('creating a table', () => {
   test('without error', async () => {
     const db = await newDB()
-    db.create(...testTable)
+    db.create(testTable)
     db.close()
   })
 
   test('with a wrong table name throws an error', async () => {
     const db = await newDB()
-    expect(() => db.create(...testTableWrongTableName)).toThrow()
+    expect(() => db.create(testTableWrongTableName)).toThrow()
     db.close()
   })
 
   test('with a wrong column name throws an error', async () => {
     const db = await newDB()
-    expect(() => db.create(...testTableWrongColumnName)).toThrow()
+    expect(() => db.create(testTableWrongColumnName)).toThrow()
     db.close()
   })
 
   test('with a wrong column type throws an error', async () => {
     const db = await newDB()
-    expect(() => db.create(...testTableWrongType)).toThrow()
+    expect(() => db.create(testTableWrongType)).toThrow()
     db.close()
   })
 
   test('with a missing type throws an error', async () => {
     const db = await newDB()
-    expect(() => db.create(...testTableMissingType)).toThrow()
+    expect(() => db.create(testTableMissingType)).toThrow()
     db.close()
   })
 })
@@ -77,22 +79,22 @@ describe('creating a table', () => {
 describe('inserting elements', () => {
   test('without error', async () => {
     const db = await newDB()
-    db.create(...testTable)
-    db.insert(testTable[0], testItems)
+    db.create(testTable)
+    db.insert(testTable.name, testItems)
     db.close()
   })
 
   test('with a wrong table name throws an error', async () => {
     const db = await newDB()
-    db.create(...testTable)
+    db.create(testTable)
     expect(() => db.insert('foobar', testItems)).toThrow()
     db.close()
   })
 
   test('with wrongly formatted items throws an error', async () => {
     const db = await newDB()
-    db.create(...testTable)
-    expect(() => db.insert(testTable[0], testWrongItems)).toThrow()
+    db.create(testTable)
+    expect(() => db.insert(testTable.name, testWrongItems)).toThrow()
     db.close()
   })
 })
@@ -100,16 +102,16 @@ describe('inserting elements', () => {
 describe('selecting', () => {
   test('all elements returns the correct elements', async () => {
     const db = await newDB()
-    db.create(...testTable)
-    db.insert(testTable[0], testItems)
+    db.create(testTable)
+    db.insert(testTable.name, testItems)
     expect(db.select('SELECT * FROM test')).toEqual(testData)
     db.close()
   })
 
   test('an element that is not present returns an empty data object', async () => {
     const db = await newDB()
-    db.create(...testTable)
-    db.insert(testTable[0], testItems)
+    db.create(testTable)
+    db.insert(testTable.name, testItems)
     expect(db.select('SELECT * FROM test WHERE id=42')).toEqual({
       headers: [],
       items: []


### PR DESCRIPTION
* add new primaryKey property
* AUTOINCREMENTED not recommended by SQLite. Instead, declare an INTEGER column as PRIMARY KEY and that column will be an alias for the implicit 'rowid' auto-incremented column. See https://www.sqlitetutorial.net/sqlite-autoincrement/. Side note that explains why we need such a column for foreign key references and cannot use rowid directly in SQLite: "The parent key must be a named column or columns in the parent table, not the [rowid](https://www.sqlite.org/lang_createtable.html#rowid)." ref: https://www.sqlite.org/foreignkeys.html. Currently, only the Twitter experience uses this feature.
* update JSON schema
* fix tests