### PR TITLE
fix: csv naming convention

### DIFF
--- a/components/chart/view/ChartViewOverviewLinkedinConnection.vue
+++ b/components/chart/view/ChartViewOverviewLinkedinConnection.vue
@@ -142,12 +142,12 @@ export default {
       // Keeps only movies and tv shows (not trailer etc..)
       this.results = this.values
       this.results.forEach((d) => {
-        d.firstname = d['First Name']
-        d.lastname = d['Last Name']
-        d.company = d.Company || 'Unknown'
-        d.position = d.Position || 'Unknown'
-        d.email = d['Email Address']
-        d.date = new Date(d['Connected On'])
+        d.firstname = d.firstName
+        d.lastname = d.lastName
+        d.company = d.company || 'Unknown'
+        d.position = d.position || 'Unknown'
+        d.email = d.emailAddress
+        d.date = new Date(d.connectedOn)
         d.week = d3.timeWeek(d.date) // pre-calculate months for better performance
         d.dateStr = formatDate(d.date)
       })

--- a/components/chart/view/ChartViewOverviewNetflix.vue
+++ b/components/chart/view/ChartViewOverviewNetflix.vue
@@ -129,11 +129,11 @@ export default {
   data() {
     return {
       header: [
-        { text: 'Date', value: 'Start Time' },
-        { text: 'Duration', value: 'Duration' },
-        { text: 'Content', value: 'Title' },
-        { text: 'User', value: 'Profile Name' },
-        { text: 'Country', value: 'Country' }
+        { text: 'Date', value: 'startTime' },
+        { text: 'Duration', value: 'duration' },
+        { text: 'Content', value: 'title' },
+        { text: 'User', value: 'profileName' },
+        { text: 'Country', value: 'country' }
       ],
       results: []
     }
@@ -175,19 +175,19 @@ export default {
 
       // Keeps only movies and tv shows (not trailer etc..)
       this.results = this.values.filter(
-        d => d['Supplemental Video Type'] === ''
+        d => d.supplementalVideoType === ''
       )
       this.results.forEach((d) => {
-        const time = d.Duration.split(':')
-        d.date = dateFormatParser(d['Start Time'])
+        const time = d.duration.split(':')
+        d.date = dateFormatParser(d.startTime)
         d.month = d3.timeMonth(d.date) // pre-calculate months for better performance
         d.dateStr = formatTime(d.day)
         d.hour = d3.timeHour(d.date).getHours()
-        const title = d.Title.split(':')
+        const title = d.title.split(':')
         d.content = title[0].includes('HIDDEN TITLE') ? title[1] : title[0]
-        d.device = d['Device Type'] === '' ? 'Unknown' : d['Device Type']
-        d.duration = +time[0] + +time[1] / 60 + +time[2] / 60 / 60
-        d.user = d['Profile Name']
+        d.device = d.deviceType === '' ? 'Unknown' : d.deviceType
+        d.durationHour = +time[0] + +time[1] / 60 + +time[2] / 60 / 60
+        d.user = d.profileName
       })
       // Create crossfilter indexing
       const ndx = crossfilter(this.results)
@@ -262,7 +262,7 @@ export default {
       const userDimension = ndx.dimension(d => d.user)
       const deviceDimension = ndx.dimension(d => d.device)
       const contentDimension = ndx.dimension(d => d.content)
-      const countryDimension = ndx.dimension(d => d.Country)
+      const countryDimension = ndx.dimension(d => d.country)
       const hourDimension = ndx.dimension(d => d.hour)
       const weekDimension = ndx.dimension((d) => {
         const day = d.date.getDay()
@@ -271,14 +271,14 @@ export default {
       })
 
       // Create groups from dimension
-      const monthGroup = monthDimension.group().reduceSum(d => d.duration)
+      const monthGroup = monthDimension.group().reduceSum(d => d.durationHour)
       // const typeGroup = typeDimension.group().reduceSum(d => d.duration)
-      const userGroup = userDimension.group().reduceSum(d => d.duration)
-      const deviceGroup = deviceDimension.group().reduceSum(d => d.duration)
-      const contentGroup = contentDimension.group().reduceSum(d => d.duration)
-      const countryGroup = countryDimension.group().reduceSum(d => d.duration)
-      const hourGroup = hourDimension.group().reduceSum(d => d.duration)
-      const weekGroup = weekDimension.group().reduceSum(d => d.duration)
+      const userGroup = userDimension.group().reduceSum(d => d.durationHour)
+      const deviceGroup = deviceDimension.group().reduceSum(d => d.durationHour)
+      const contentGroup = contentDimension.group().reduceSum(d => d.durationHour)
+      const countryGroup = countryDimension.group().reduceSum(d => d.durationHour)
+      const hourGroup = hourDimension.group().reduceSum(d => d.durationHour)
+      const weekGroup = weekDimension.group().reduceSum(d => d.durationHour)
 
       // Render watch time line chart
       const minDate = monthDimension.bottom(1)[0].date

--- a/components/chart/view/ChartViewOverviewUber.vue
+++ b/components/chart/view/ChartViewOverviewUber.vue
@@ -206,7 +206,7 @@ export default {
   data() {
     return {
       header: [
-        { text: 'City', value: 'City' },
+        { text: 'City', value: 'city' },
         { text: 'Service', value: 'service' },
         { text: 'Status', value: 'tripOrOrderStatus' },
         { text: 'Request Time', value: 'dateRequestStr' },

--- a/components/chart/view/LinkedinAdTargeting.vue
+++ b/components/chart/view/LinkedinAdTargeting.vue
@@ -69,6 +69,7 @@ export default {
   },
   computed: {
     items() {
+      console.log(this.values)
       return Object.keys(this.values[0])
         .sort()
         .map((k) => {
@@ -81,7 +82,9 @@ export default {
     }
   },
   methods: {
-    drawViz() {}
+    drawViz() {
+      console.log('Test', this.values)
+    }
   }
 }
 </script>

--- a/components/chart/view/ListLinkedinInference.vue
+++ b/components/chart/view/ListLinkedinInference.vue
@@ -91,18 +91,18 @@ export default {
       return this.values
         .map((inference) => {
           const inferenceType =
-            inference.Inference === 'true'
+            inference.inference === 'true'
               ? 'True'
-              : inference.Inference === 'No'
+              : inference.inference === 'No'
                 ? 'False'
                 : 'Others'
           let value = inferenceType
-          if (value === 'Others') { value = parseFloat(inference.Inference).toFixed(2) }
+          if (value === 'Others') { value = parseFloat(inference.inference).toFixed(2) }
 
           return {
-            type: inference['Type of inference'],
-            category: inference.Category,
-            description: inference.Description,
+            type: inference.typeOfInference,
+            category: inference.category,
+            description: inference.description,
             inferenceValue: value,
             inferenceType,
             color:
@@ -125,7 +125,7 @@ export default {
         )
     },
     categories() {
-      return this.values.map(inference => inference.Category)
+      return this.values.map(inference => inference.category)
     }
   },
   methods: {

--- a/utils/csv.js
+++ b/utils/csv.js
@@ -26,7 +26,10 @@ async function getCsvHeadersAndItems(csvText) {
             headers: headers => differentiateDuplicates(headers.map(camelCase)),
             strictColumnHandling: true
           })
-          .on('headers', h => headers.push(...h))
+          .on('headers', (h) => {
+            headers.push(...h.map(h => camelCase(h)))
+          }
+          )
           .on('data', (row) => {
             return items.push(
               Object.fromEntries(


### PR DESCRIPTION
A bug was introduced when forcing CSVs headers to be in pascalCase, The transformation was only made on the values and not the headers. This makes the DataValidator fails. After fixing it I had to adapt Uber, Netflix, Her and Linkedin experiences accordingly.