### PR TITLE
Simplify i18n slightly

### DIFF
--- a/experiences/components/TheDataExperience.vue
+++ b/experiences/components/TheDataExperience.vue
@@ -32,7 +32,7 @@
             nuxt
             :to="`#${t.value}`"
           >
-            {{ $tetv(k(t.value), `${t.value}.name`, t.title) }}
+            {{ $tev(t.titleKey, t.title) }}
           </VTab>
         </VTabs>
         <VTabsItems v-model="tab">
@@ -153,6 +153,7 @@ export default {
         {
           title: 'Load your data',
           value: 'load-data',
+          titleKey: 'load-data.name',
           disabled: this.experienceProgress
         },
         ...(!this.hideSummary
@@ -160,6 +161,7 @@ export default {
               {
                 title: 'Summary',
                 value: 'summary',
+                titleKey: 'summary.name',
                 disabled
               }
             ]
@@ -169,6 +171,7 @@ export default {
               {
                 title: 'Files',
                 value: 'file-explorer',
+                titleKey: 'file-explorer.name',
                 disabled
               }
             ]
@@ -176,6 +179,7 @@ export default {
         ...this.viewBlocks.map(view => ({
           ...view,
           value: view.id,
+          titleKey: this.k(view.id),
           disabled,
           show: true
         }))
@@ -184,6 +188,7 @@ export default {
         tabs.push({
           title: 'Share my data',
           value: 'share-data',
+          titleKey: 'share-data.name',
           disabled
         })
       }

--- a/experiences/components/__tests__/TheDataExperience.test.js
+++ b/experiences/components/__tests__/TheDataExperience.test.js
@@ -73,8 +73,7 @@ test('mounts without error', () => {
       },
       $t: msg => defaultMessages.en[msg],
       $tev: msg => defaultMessages.en[msg],
-      $tet: msg => defaultMessages.en[msg],
-      $tetv: msg => defaultMessages.en[msg]
+      $tet: msg => defaultMessages.en[msg]
     }
   })
   expect(wrapper.exists()).toBeTruthy()
@@ -99,8 +98,7 @@ test('process simple text file', async() => {
       },
       $t: msg => defaultMessages.en[msg],
       $tev: msg => defaultMessages.en[msg],
-      $tet: msg => defaultMessages.en[msg],
-      $tetv: msg => defaultMessages.en[msg]
+      $tet: msg => defaultMessages.en[msg]
     }
   })
 

--- a/experiences/components/unit/UnitQuery.vue
+++ b/experiences/components/unit/UnitQuery.vue
@@ -5,7 +5,7 @@
         <VCol cols="1" />
         <VCol cols="10">
           <VCardTitle class="justify-center">
-            {{ $tetv(k('title'),`${id}.title`, title) }}
+            {{ $tev(k('title'), title) }}
           </VCardTitle>
         </VCol>
         <VCol cols="1" align-self="center" class="full-height text-center">
@@ -31,7 +31,7 @@
       <VRow v-if="text">
         <VCol>
           <VContainer>
-            {{ $tetv(k('text'),`${id}.text`, text) }}
+            {{ $tev(k('text'), text) }}
           </VContainer>
         </VCol>
       </VRow>

--- a/experiences/config/dev.json
+++ b/experiences/config/dev.json
@@ -41,8 +41,7 @@
     "voi",
     "whatsapp",
     "wolt",
-    "youtube",
-    "explorer"
+    "youtube"
   ],
   "appBarLinks": [
     { "url": "/about", "name": "About" },

--- a/experiences/config/dev.json
+++ b/experiences/config/dev.json
@@ -41,7 +41,8 @@
     "voi",
     "whatsapp",
     "wolt",
-    "youtube"
+    "youtube",
+    "explorer"
   ],
   "appBarLinks": [
     { "url": "/about", "name": "About" },

--- a/experiences/i18n-messages-default.json
+++ b/experiences/i18n-messages-default.json
@@ -93,26 +93,6 @@
         }
       }
     },
-    "genericDateViewer": {
-      "name": "Timeline",
-      "title": "Timeline",
-      "text": "See all the dated events in your files, corresponding to data that has been collected on you at or concerning a specific date.",
-      "graph-title": "Number of dated events in your files",
-      "graph-no-date": "No dated events were found in your file(s).",
-      "from": "From",
-      "to": "to",
-      "found": "we found",
-      "dated-event": "dated events in your file(s)."
-    },
-    "genericLocationViewer": {
-      "name": "Location Observations",
-      "title": "Location Observations",
-      "text": "See all the location events in your files, corresponding to data that has been collected on you at or concerning a specific location.",
-      "graph-title": "Number of location records in your files",
-      "graph-no-location": "No location were found in your file(s).",
-      "found": "We found",
-      "location": "locations in your file(s)."
-    },
     "generic-map": {
       "search-info": "Please use the search box and filters below to change what is shown on the map.",
       "add-noise": "Add Noise",
@@ -277,26 +257,6 @@
           "Create table": "Créer un tableau"
         }
       }
-    },
-    "genericDateViewer": {
-      "name": "Chronologie",
-      "title": "Chronologie",
-      "text": "Voir tous les événements datés dans vos dossiers, correspondant aux données qui ont été collectées sur vous à ou concernant une date spécifique.",
-      "graph-title": "Nombre d'événements datés dans vos dossiers",
-      "graph-no-date": "Aucun événement daté n'a été trouvé dans votre (vos) dossier(s).",
-      "from": "De",
-      "to": "à",
-      "found": "nous avons trouvé",
-      "dated-event": "événements datés dans votre (vos) fichier(s)."
-    },
-    "genericLocationViewer": {
-      "name": "Positions",
-      "title": "Observations de localisation",
-      "text": "Voir tous les événements de localisation dans vos fichiers, correspondant aux données qui ont été collectées sur vous à ou concernant un lieu spécifique.",
-      "graph-title": "Nombre de localisation dans vos fichiers",
-      "graph-no-location": "Aucune localisation n'a été trouvé dans votre/vos fichier(s).",
-      "found": "Nous avons trouvé",
-      "location": "dans votre/vos fichier(s)."
     },
     "generic-map": {
       "search-info": "Veuillez utiliser le champ de recherche et les filtres ci-dessous pour modifier ce qui est affiché sur la carte.",

--- a/experiences/plugins/injected.js
+++ b/experiences/plugins/injected.js
@@ -20,8 +20,4 @@ export default ({ app }, inject) => {
     // tet -> Translation Exists (else) Translate fallback
     return i18n.te(key) ? i18n.t(key) : i18n.t(keyFallback)
   })
-  inject('tetv', (key, keyFallback, valueFallback) => {
-    // tet -> Translation Exists (else) Translate fallback (else) Value fallback
-    return i18n.te(key) ? i18n.t(key) : i18n.te(keyFallback) ? i18n.t(keyFallback) : valueFallback
-  })
 }

--- a/packages/lib/pipelines/generic-messages.json
+++ b/packages/lib/pipelines/generic-messages.json
@@ -1,0 +1,46 @@
+{
+  "en": {
+    "genericDateViewer": {
+      "name": "Timeline",
+      "title": "Timeline",
+      "text": "See all the dated events in your files, corresponding to data that has been collected on you at or concerning a specific date.",
+      "graph-title": "Number of dated events in your files",
+      "graph-no-date": "No dated events were found in your file(s).",
+      "from": "From",
+      "to": "to",
+      "found": "we found",
+      "dated-event": "dated events in your file(s)."
+    },
+    "genericLocationViewer": {
+      "name": "Location Observations",
+      "title": "Location Observations",
+      "text": "See all the location events in your files, corresponding to data that has been collected on you at or concerning a specific location.",
+      "graph-title": "Number of location records in your files",
+      "graph-no-location": "No location were found in your file(s).",
+      "found": "We found",
+      "location": "locations in your file(s)."
+    }
+  },
+  "fr": {
+    "genericDateViewer": {
+      "name": "Chronologie",
+      "title": "Chronologie",
+      "text": "Voir tous les événements datés dans vos dossiers, correspondant aux données qui ont été collectées sur vous à ou concernant une date spécifique.",
+      "graph-title": "Nombre d'événements datés dans vos dossiers",
+      "graph-no-date": "Aucun événement daté n'a été trouvé dans votre (vos) dossier(s).",
+      "from": "De",
+      "to": "à",
+      "found": "nous avons trouvé",
+      "dated-event": "événements datés dans votre (vos) fichier(s)."
+    },
+    "genericLocationViewer": {
+      "name": "Positions",
+      "title": "Observations de localisation",
+      "text": "Voir tous les événements de localisation dans vos fichiers, correspondant aux données qui ont été collectées sur vous à ou concernant un lieu spécifique.",
+      "graph-title": "Nombre de localisation dans vos fichiers",
+      "graph-no-location": "Aucune localisation n'a été trouvé dans votre/vos fichier(s).",
+      "found": "Nous avons trouvé",
+      "location": "dans votre/vos fichier(s)."
+    }
+  }
+}

--- a/packages/packages/explorer/src/index.ts
+++ b/packages/packages/explorer/src/index.ts
@@ -2,8 +2,22 @@ import packageJSON from '../package.json'
 import { Experience, ExperienceOptions } from '@/index'
 import icon from '@/icons/clipboard-search-outline.png'
 import { genericViewers as viewBlocks } from '@/pipelines/generic'
-import messages from './messages.json'
+import viewBlockMessagesJson from '@/pipelines/generic-messages.json'
+import messagesJson from './messages.json'
 
+// There must be a better way to declare types...
+const viewBlockMessages: any = viewBlockMessagesJson
+const messages: any = messagesJson
+
+// merge explorer messages with generic block messages
+Object.keys(viewBlockMessages).forEach(lang => {
+  const vbLangMess = viewBlockMessages[lang]
+  const viewBlocks = messages[lang].viewBlocks || {}
+  messages[lang].viewBlocks = viewBlocks
+  Object.keys(vbLangMess).forEach(viewBlockId => {
+    viewBlocks[viewBlockId] = vbLangMess[viewBlockId]
+  })
+})
 const options: ExperienceOptions = {
   hideSummary: false,
   hideFileExplorer: false,


### PR DESCRIPTION
Reading the code, I had really a hard time understanding from where some of the translations came, particularly where the **tetv** function was used. 

I think I understood why it was there and did some refactoring to make things more explicit. 

I moved the messages for the generic viewers back to packages where the blocks are defined, and deleted them from i18n-messages-default.json.

And I deleted **tetv**