### PR TITLE
remove translation of headers in kepler config since it relies on raw names

### DIFF
--- a/experiences/components/chart/view/ChartViewGenericMap.vue
+++ b/experiences/components/chart/view/ChartViewGenericMap.vue
@@ -155,7 +155,7 @@ export default {
       return {
         fields: this.headers.map((h) => {
           return {
-            name: this.$tev(this.kViewBlock(h, 'headers'), h)
+            name: h
           }
         }),
         rows: this.filteredRows.map(r => this.headers.map(h => r[h]))


### PR DESCRIPTION
This PR fix #1028 
