### PR TITLE
Add automatic width for kepler embeds, to remove white box

### DIFF
--- a/experiences/components/unit/UnitKepler.vue
+++ b/experiences/components/unit/UnitKepler.vue
@@ -45,6 +45,7 @@ function buildIframeHtml() {
           ${headerScripts.join('\n')}
           <style type="text/css">
             body { margin: 0; padding: 0; overflow: hidden; }
+            #app, #app .kepler-gl { width: auto; }
           </style>
         </head>
         <body>


### PR DESCRIPTION
Ensure kepler embedded div uses all available width, not a lesser default width that was being specified. 

Fixes #1095.