### PR TITLE
feat: add ability to insert an image in a tab + overlay message in case of future features

### DIFF
--- a/experiences/components/unit/UnitQuery.vue
+++ b/experiences/components/unit/UnitQuery.vue
@@ -65,7 +65,6 @@
           }"
           @update="onUnitResultsUpdate"
         />
-
         <VRow v-if="errorMessage">
           <VCol>
             <BaseAlert type="error">
@@ -73,6 +72,7 @@
             </BaseAlert>
           </VCol>
         </VRow>
+        <VImg v-if="image" :src="image" />
         <template v-if="clonedResult">
           <VRow>
             <VCol>
@@ -157,6 +157,10 @@ export default {
     showTable: {
       type: Boolean,
       required: true
+    },
+    image: {
+      type: String,
+      default: ''
     },
     vizProps: {
       type: Object,

--- a/experiences/components/unit/UnitQuery.vue
+++ b/experiences/components/unit/UnitQuery.vue
@@ -1,5 +1,15 @@
 <template>
   <div>
+    <VOverlay :value="overlay !== ''" absolute opacity="0.5">
+      <div
+        class="d-flex flex-column align-center"
+        style="width: 100%; height: 100%"
+      >
+        <div class="mb-3">
+          {{ $tev(k('overlay'), overlay) }}
+        </div>
+      </div>
+    </VOverlay>
     <VCard v-if="fileManager !== null" class="pa-2 mb-6" flat>
       <VRow>
         <VCol cols="1" />
@@ -159,6 +169,10 @@ export default {
       required: true
     },
     image: {
+      type: String,
+      default: ''
+    },
+    overlay: {
       type: String,
       default: ''
     },

--- a/packages/lib/types/view-block.ts
+++ b/packages/lib/types/view-block.ts
@@ -13,6 +13,8 @@ export type ViewBlock = {
   customPipelineOptions?: CustomPipelineOptions
   files?: string[]
   id: string
+  image?: string
+  overlay?: string
   postprocessor?: PostprocessorFunction
   showTable?: boolean
   sql?: string

--- a/packages/packages/uber-driver/package.json
+++ b/packages/packages/uber-driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hestia.ai/uber-driver",
-  "version": "0.0.1-alpha.24",
+  "version": "0.0.1-alpha.25",
   "main": "dist/index",
   "type": "module",
   "files": [

--- a/packages/packages/uber-driver/package.json
+++ b/packages/packages/uber-driver/package.json
@@ -15,5 +15,6 @@
     "access": "public"
   },
   "author": "",
-  "license": "UNLICENSED"
+  "license": "UNLICENSED",
+  "gitHead": "e1210e21daff4c42aff12c0f3f6e0b06e49ee212"
 }

--- a/packages/packages/uber-driver/src/blocks.ts
+++ b/packages/packages/uber-driver/src/blocks.ts
@@ -88,10 +88,10 @@ const blocks: ViewBlocks = [
   {
     id: 'driverAccounting',
     title: 'Accounting (Mockup)',
-    text: 'This table represent blablabla',
+    text: 'See how you worked and during which pay period.',
     image:
-      'https://user-images.githubusercontent.com/17878016/198039639-ebc25347-2c29-4570-a19b-7495d8792cf7.png',
-    overlay: 'Coming Soon'
+      'https://user-images.githubusercontent.com/17878016/199244607-dd9a8b19-fc12-4780-b67e-d8460086d1c0.png',
+    overlay: 'This feature is still under construction'
   }
 ]
 

--- a/packages/packages/uber-driver/src/blocks.ts
+++ b/packages/packages/uber-driver/src/blocks.ts
@@ -84,6 +84,14 @@ const blocks: ViewBlocks = [
       keplerConfig: keplerConfigNonTrip,
       label: 'in between trips'
     }
+  },
+  {
+    id: 'driverAccounting',
+    title: 'Accounting (Mockup)',
+    text: 'This table represent blablabla',
+    image:
+      'https://user-images.githubusercontent.com/17878016/198039639-ebc25347-2c29-4570-a19b-7495d8792cf7.png',
+    overlay: 'Coming Soon'
   }
 ]
 


### PR DESCRIPTION
This issue is related to #1127 and #1115.

Added two parameters in the experience config, a viewBlock can now have the following two attributes: 
`image`: (string) given an URL, insert an image below the `description` field.
`overlay`: (string) Given a message, add an overlay to the entire content of the tab, displaying that message.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/17878016/199247410-f047c610-8b56-416a-870c-306c174cac81.png">
